### PR TITLE
Sprint 3: Starter factories, seeders, and factory-based feature tests

### DIFF
--- a/app/Models/User.ts
+++ b/app/Models/User.ts
@@ -1,25 +1,9 @@
-import { Column, Model, Table } from "@ninots/framework";
+import { Model, Table } from "@ninots/framework";
 
 /**
  * User model.
  */
 @Table("users")
 export class User extends Model {
-    @Column({ primary: true, autoIncrement: true })
-    public id!: number;
-
-    @Column({ unique: true })
-    public email!: string;
-
-    @Column()
-    public name!: string;
-
-    @Column({ hidden: true })
-    public password!: string;
-
-    @Column({ nullable: true })
-    public avatar!: string;
-
-    @Column({ type: "json", nullable: true })
-    public metadata!: Record<string, unknown>;
+    protected static override fillable = ["email", "name", "password", "avatar", "metadata"];
 }

--- a/bootstrap/app.ts
+++ b/bootstrap/app.ts
@@ -1,6 +1,7 @@
 import { Application, Container, createServeOptions, wireCoreServices } from "@ninots/framework";
 import type { Serve } from "bun";
 import appConfig from "@/config/app";
+import { getDatabaseManager } from "./database";
 import { registerProviders } from "./providers";
 
 export { createServeOptions };
@@ -22,6 +23,7 @@ export async function bootstrap(): Promise<Application> {
     );
 
     wireCoreServices(app);
+    getDatabaseManager();
     await registerProviders(app);
     await app.boot();
 

--- a/bootstrap/database.ts
+++ b/bootstrap/database.ts
@@ -1,0 +1,38 @@
+import { DatabaseManager, Model } from "@ninots/framework";
+import databaseConfig from "@/config/database";
+import "@/database/factories/UserFactory";
+
+let databaseManager: DatabaseManager | null = null;
+
+/**
+ * Build a DatabaseManager from application config.
+ */
+export function createDatabaseManager(): DatabaseManager {
+    const manager = new DatabaseManager();
+
+    for (const [name, connection] of Object.entries(databaseConfig.connections)) {
+        manager.addConnection(name, connection);
+    }
+
+    manager.setDefaultConnection(databaseConfig.default);
+    return manager;
+}
+
+/**
+ * Resolve the singleton database manager and wire the ORM resolver.
+ */
+export function getDatabaseManager(): DatabaseManager {
+    if (!databaseManager) {
+        databaseManager = createDatabaseManager();
+        Model.setConnectionResolver(databaseManager);
+    }
+
+    return databaseManager;
+}
+
+/**
+ * Reset database manager (used in tests).
+ */
+export function resetDatabaseManager(manager?: DatabaseManager | null): void {
+    databaseManager = manager ?? null;
+}

--- a/config/database.ts
+++ b/config/database.ts
@@ -10,7 +10,7 @@ export default {
     connections: {
         sqlite: {
             driver: "sqlite",
-            database: "storage/database.sqlite",
+            filename: "storage/database.sqlite",
             foreignKeys: true,
         },
         postgres: {

--- a/database/factories/UserFactory.ts
+++ b/database/factories/UserFactory.ts
@@ -1,0 +1,33 @@
+import { configureModelFactory, Factory, fake } from "@ninots/framework";
+import { User } from "@/app/Models/User";
+
+export type UserFactoryAttributes = {
+    name: string;
+    email: string;
+    password: string;
+    avatar?: string | null;
+    metadata?: Record<string, unknown> | null;
+};
+
+/**
+ * Factory for generating User records in tests and seeders.
+ */
+export class UserFactory extends Factory<User, UserFactoryAttributes> {
+    definition(): UserFactoryAttributes {
+        return {
+            email: fake.uniqueEmail(),
+            name: fake.name(),
+            password: fake.password(),
+        };
+    }
+
+    model() {
+        return User;
+    }
+
+    unverified() {
+        return this.state({ metadata: { email_verified_at: null } });
+    }
+}
+
+configureModelFactory(User, UserFactory);

--- a/database/migrations/2024_01_01_create_users_table.ts
+++ b/database/migrations/2024_01_01_create_users_table.ts
@@ -1,14 +1,23 @@
-import type { Migration } from "@ninots/framework";
+import type { Connection, Migration } from "@ninots/framework";
 
 /**
  * Create users table migration.
  */
 export default class CreateUsersTable implements Migration {
-    public async up(): Promise<void> {
-        // CREATE TABLE users (...)
+    public async up(connection: Connection): Promise<void> {
+        await connection.run(`
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL UNIQUE,
+                name TEXT NOT NULL,
+                password TEXT NOT NULL,
+                avatar TEXT,
+                metadata TEXT
+            )
+        `);
     }
 
-    public async down(): Promise<void> {
-        // DROP TABLE users;
+    public async down(connection: Connection): Promise<void> {
+        await connection.run("DROP TABLE IF EXISTS users");
     }
 }

--- a/database/seeders/DatabaseSeeder.ts
+++ b/database/seeders/DatabaseSeeder.ts
@@ -1,0 +1,14 @@
+import { Seeder } from "@ninots/framework";
+import { User } from "@/app/Models/User";
+
+/**
+ * Seed the application's database.
+ */
+export class DatabaseSeeder extends Seeder {
+    async run(): Promise<void> {
+        await User.factory().create({
+            email: "test@example.com",
+            name: "Test User",
+        });
+    }
+}

--- a/nino.ts
+++ b/nino.ts
@@ -1,7 +1,21 @@
-import { Command, Kernel, ROUTER_KEY } from "@ninots/framework";
+import path from "node:path";
+import {
+    Command,
+    DbSeedCommand,
+    Kernel,
+    MigrateCommand,
+    Migrator,
+    ROUTER_KEY,
+    SeederRunner,
+} from "@ninots/framework";
 import type { Router } from "@ninots/framework";
 import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
+import { getDatabaseManager } from "@/bootstrap/database";
+import databaseConfig from "@/config/database";
+import { DatabaseSeeder } from "@/database/seeders/DatabaseSeeder";
 import packageJson from "./package.json";
+
+const migrationsPath = path.join(process.cwd(), databaseConfig.migrations.directory);
 
 class HelpCommand extends Command {
     protected signature = "help";
@@ -106,6 +120,26 @@ kernel.register(new VersionCommand());
 kernel.register(new ServeCommand());
 kernel.register(new RoutesCommand());
 kernel.register(new CacheClearCommand());
+kernel.register(
+    new MigrateCommand({
+        resolveMigrator: () => {
+            getDatabaseManager();
+            return new Migrator({
+                database: getDatabaseManager(),
+                path: migrationsPath,
+                table: databaseConfig.migrations.table,
+            });
+        },
+    }),
+);
+kernel.register(
+    new DbSeedCommand({
+        resolveSeederRunner: () => {
+            getDatabaseManager();
+            return new SeederRunner(DatabaseSeeder);
+        },
+    }),
+);
 
 const exitCode = await kernel.run(process.argv.slice(2));
 process.exit(exitCode);

--- a/tests/Feature/UserFactory.test.ts
+++ b/tests/Feature/UserFactory.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { User } from "@/app/Models/User";
+import { setupTestDatabase, teardownTestDatabase } from "@/tests/support/database";
+
+describe("UserFactory", () => {
+    beforeEach(async () => {
+        await setupTestDatabase();
+    });
+
+    afterEach(async () => {
+        await teardownTestDatabase();
+    });
+
+    test("creates a persisted user with factory defaults", async () => {
+        const user = await User.factory().create();
+
+        expect(user.id).toBeDefined();
+        expect(user.name).toBeString();
+        expect(user.email).toContain("@");
+    });
+
+    test("count() creates multiple users", async () => {
+        const users = await User.factory(2).create();
+
+        expect(users).toHaveLength(2);
+        expect(users[0]?.email).not.toBe(users[1]?.email);
+    });
+
+    test("state() overrides attributes without hardcoded fixtures", async () => {
+        const user = await User.factory()
+            .state({ name: "Seeded Nova" })
+            .create();
+
+        expect(user.name).toBe("Seeded Nova");
+    });
+});

--- a/tests/Feature/UserService.test.ts
+++ b/tests/Feature/UserService.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EVENT_DISPATCHER_KEY } from "@ninots/framework";
+import type { EventDispatcher } from "@ninots/framework";
+import { UserService } from "@/app/Services/UserService";
+import { User } from "@/app/Models/User";
+import { bootstrap } from "@/bootstrap/app";
+import { setupTestDatabase, teardownTestDatabase } from "@/tests/support/database";
+
+describe("UserService with Factory", () => {
+    beforeEach(async () => {
+        await setupTestDatabase();
+    });
+
+    afterEach(async () => {
+        await teardownTestDatabase();
+    });
+
+    test("creates users using factory-generated attributes", async () => {
+        const app = await bootstrap();
+        const events = app.make<EventDispatcher>(EVENT_DISPATCHER_KEY);
+        const service = new UserService(events);
+
+        const template = await User.factory().make();
+        const created = await service.create({
+            email: template.email,
+            name: template.name,
+            password: template.password,
+        });
+
+        const found = await service.find(created.id as number);
+
+        expect(found?.email).toBe(template.email);
+        expect(found?.name).toBe(template.name);
+    });
+});

--- a/tests/support/database.ts
+++ b/tests/support/database.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+import { DatabaseManager, Migrator, Model } from "@ninots/framework";
+import { resetDatabaseManager } from "@/bootstrap/database";
+import databaseConfig from "@/config/database";
+
+let activeDatabase: DatabaseManager | null = null;
+
+const migrationsPath = path.join(process.cwd(), databaseConfig.migrations.directory);
+
+/**
+ * Boot an in-memory SQLite database with migrations applied (for feature tests).
+ */
+export async function setupTestDatabase(): Promise<DatabaseManager> {
+    const database = new DatabaseManager();
+    database.addConnection("default", {
+        database: ":memory:",
+        driver: "sqlite",
+        url: ":memory:",
+    });
+    database.setDefaultConnection("default");
+    Model.setConnectionResolver(database);
+    resetDatabaseManager(database);
+
+    const migrator = new Migrator({
+        database,
+        path: migrationsPath,
+        table: databaseConfig.migrations.table,
+    });
+    await migrator.run();
+
+    activeDatabase = database;
+    return database;
+}
+
+/**
+ * Tear down the in-memory test database.
+ */
+export async function teardownTestDatabase(): Promise<void> {
+    if (activeDatabase) {
+        await activeDatabase.closeALl();
+        activeDatabase = null;
+    }
+    resetDatabaseManager(null);
+}


### PR DESCRIPTION
## Summary
- Add database/factories/UserFactory.ts and database/seeders/DatabaseSeeder.ts
- Wire database bootstrap, nino migrate + db:seed CLI commands
- Fix sqlite config to use filename (persistent storage/database.sqlite)
- Add feature tests using Factory instead of hardcoded fixtures

## Issues
Fixes #10, Fixes #11

## Test plan
- [x] bun test (ninots) — 6 pass
- [x] bun run nino.ts migrate
- [x] bun run nino.ts db:seed
- [ ] Requires published @ninots/framework 0.4.0+ with Factory/Seeder (currently bun link)

Made with [Cursor](https://cursor.com)