### PR TITLE
feat(web): wire welcome view via @ninots/view (Sprint 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "test": "bun test"
     },
     "dependencies": {
-        "@ninots/framework": "link:@ninots/framework"
+        "@ninots/framework": "link:@ninots/framework",
+        "@ninots/view": "link:@ninots/view"
     },
     "devDependencies": {
         "@biomejs/biome": "2.4.14",

--- a/resources/views/layouts/app.tsx
+++ b/resources/views/layouts/app.tsx
@@ -1,0 +1,109 @@
+const APP_STYLES = `
+:root {
+    color-scheme: light dark;
+    --bg: #0f172a;
+    --surface: #1e293b;
+    --text: #f8fafc;
+    --muted: #94a3b8;
+    --accent: #38bdf8;
+    --border: #334155;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: "Segoe UI", system-ui, sans-serif;
+    background: radial-gradient(circle at top, #1e3a5f 0%, var(--bg) 55%);
+    color: var(--text);
+}
+
+.site-header,
+.site-footer,
+.site-main {
+    width: min(960px, calc(100% - 2rem));
+    margin-inline: auto;
+}
+
+.site-header {
+    padding: 2rem 0 1rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.brand {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+
+.tagline {
+    margin: 0.35rem 0 0;
+    color: var(--muted);
+}
+
+.site-main {
+    padding: 2.5rem 0 3rem;
+}
+
+.welcome {
+    background: color-mix(in srgb, var(--surface) 88%, transparent);
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    padding: 2rem;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+}
+
+.welcome h1 {
+    margin: 0 0 0.75rem;
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.welcome p {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+.welcome strong {
+    color: var(--accent);
+}
+
+.site-footer {
+    padding: 1.5rem 0 2rem;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+`;
+
+export interface AppLayoutProps {
+    title: string;
+    children: string;
+}
+
+export function AppLayout({ title, children }: AppLayoutProps) {
+    return (
+        <html lang="en">
+            <head>
+                <meta charSet="utf-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <title>{title}</title>
+                <style dangerouslySetInnerHTML={{ __html: APP_STYLES }} />
+            </head>
+            <body>
+                <header className="site-header">
+                    <p className="brand">Ninots</p>
+                    <p className="tagline">Laravel-like starter on Bun</p>
+                </header>
+                <main className="site-main" dangerouslySetInnerHTML={{ __html: children }} />
+                <footer className="site-footer">
+                    <p>Built with Bun + TypeScript</p>
+                </footer>
+            </body>
+        </html>
+    );
+}

--- a/resources/views/welcome.tsx
+++ b/resources/views/welcome.tsx
@@ -1,0 +1,19 @@
+import { withLayout } from "@ninots/view";
+import { AppLayout } from "@/resources/views/layouts/app.tsx";
+
+export interface WelcomeProps {
+    subtitle?: string;
+}
+
+function WelcomePage({ subtitle = "Your application is ready. Start building in routes/web.ts." }: WelcomeProps) {
+    return (
+        <section className="welcome">
+            <h1>Welcome to Ninots</h1>
+            <p>
+                {subtitle} Explore <strong>api</strong>, <strong>web</strong>, and <strong>websocket</strong> surfaces.
+            </p>
+        </section>
+    );
+}
+
+export const Welcome = withLayout(AppLayout, WelcomePage, { title: "Ninots" });

--- a/routes/web.ts
+++ b/routes/web.ts
@@ -1,8 +1,14 @@
+import { render } from "@ninots/view";
 import type { Router } from "@ninots/framework";
+import { Welcome } from "@/resources/views/welcome.tsx";
 
 /**
- * Web routes (HTML pages, future views).
+ * Web routes (HTML pages rendered via @ninots/view).
  */
 export function registerWebRoutes(router: Router): void {
-    router.get("/", () => new Response("Ninots — Laravel-like starter on Bun", { status: 200 }));
+    router.get("/", () =>
+        render(Welcome, {
+            subtitle: "Laravel-like DX on Bun.",
+        }),
+    );
 }

--- a/tests/Feature/WebRoute.test.ts
+++ b/tests/Feature/WebRoute.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { render } from "@ninots/view";
+import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
+import { Welcome } from "@/resources/views/welcome.tsx";
+
+describe("Web routes", () => {
+    test("GET / returns rendered HTML welcome page", async () => {
+        const app = await bootstrap();
+        const server = Bun.serve({
+            ...createAppServeOptions(app),
+            port: 0,
+            hostname: "127.0.0.1",
+        });
+
+        try {
+            const response = await fetch(`http://127.0.0.1:${server.port}/`);
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get("Content-Type")).toContain("text/html");
+
+            const html = await response.text();
+            expect(html).toContain("Welcome to Ninots");
+            expect(html).toContain("<title>Ninots</title>");
+            expect(html).toContain("Laravel-like starter on Bun");
+        } finally {
+            server.stop();
+        }
+    });
+
+    test("welcome view escapes XSS payloads in dynamic text", async () => {
+        const payload = '<script>alert("xss")</script>';
+        const response = await render(Welcome, { subtitle: payload });
+        const html = await response.text();
+
+        expect(html).not.toContain("<script>");
+        expect(html).toContain("&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;");
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "module": "ESNext",
         "moduleDetection": "force",
         "jsx": "react-jsx",
+        "jsxImportSource": "@ninots/view",
         "allowJs": false,
         "types": ["bun"],
         // Bundler mode


### PR DESCRIPTION
## Summary
- Add \esources/views/layouts/app.tsx\ layout with minimal Ninots styling (inline CSS)
- Add \esources/views/welcome.tsx\ welcome page composed with \withLayout()\
- Wire \outes/web.ts\ GET \/\ to \ender(Welcome)\ instead of plain string \Response\
- Feature tests: HTML \Content-Type\, welcome title, XSS escape case

Depends on framework PR for \@ninots/view\.

Fixes #13
Fixes #14

## Test plan
- [x] \un test\ — 8 pass, 0 fail (includes \WebRoute.test.ts\)
- [x] GET \/\ returns \	ext/html\ with rendered welcome
- [x] XSS payload in subtitle is escaped
- [ ] Ivy QA sign-off

Made with [Cursor](https://cursor.com)