### PR TITLE
chore(ts): align starter TS hygiene

### DIFF
--- a/app/Http/Controllers/Controller.ts
+++ b/app/Http/Controllers/Controller.ts
@@ -3,11 +3,11 @@
  */
 export abstract class Controller {
     protected json(data: unknown, status = 200): Response {
-        return Response.json(data, status);
+        return Response.json(data, { status });
     }
 
     protected created(data: unknown): Response {
-        return Response.json(data, 201);
+        return Response.json(data, { status: 201 });
     }
 
     protected noContent(): Response {
@@ -19,6 +19,6 @@ export abstract class Controller {
     }
 
     protected error(message: string, status = 400): Response {
-        return Response.json({ error: message }, status);
+        return Response.json({ error: message }, { status });
     }
 }

--- a/app/Http/Middleware/CorsMiddleware.ts
+++ b/app/Http/Middleware/CorsMiddleware.ts
@@ -1,8 +1,10 @@
 import type { Middleware } from "@ninots/framework";
 
+type NextHandler = (request: Request) => Response | Promise<Response>;
+
 /**
  * CORS middleware placeholder — wire when HTTP pipeline needs it.
  */
-export const CorsMiddleware: Middleware = async (request, next) => {
+export const CorsMiddleware: Middleware = async (request: Request, next: NextHandler) => {
     return next(request);
 };

--- a/app/Http/Requests/CreateUserRequest.ts
+++ b/app/Http/Requests/CreateUserRequest.ts
@@ -13,7 +13,7 @@ export class CreateUserRequest extends FormRequest {
         };
     }
 
-    public messages(): Record<string, string> {
+    public override messages(): Record<string, string> {
         return {
             "email.required": "The email is required",
             "email.email": "The email must be valid",

--- a/app/Providers/AppServiceProvider.ts
+++ b/app/Providers/AppServiceProvider.ts
@@ -12,7 +12,7 @@ export class AppServiceProvider extends ServiceProvider {
         super(app.container);
     }
 
-    public register(): void {
+    public override register(): void {
         const events = this.app.make<EventDispatcher>(EVENT_DISPATCHER_KEY);
 
         this.app.singleton(UserService.name, () => new UserService(events));

--- a/app/Providers/EventServiceProvider.ts
+++ b/app/Providers/EventServiceProvider.ts
@@ -12,7 +12,7 @@ export class EventServiceProvider extends ServiceProvider {
         super(app.container);
     }
 
-    public register(): void {
+    public override register(): void {
         const dispatcher = this.app.make<EventDispatcher>(EVENT_DISPATCHER_KEY);
         const bus = this.app.make<SyncBus>(SYNC_BUS_KEY);
         const listener = new SendWelcomeEmailListener(bus);

--- a/app/Providers/RouteServiceProvider.ts
+++ b/app/Providers/RouteServiceProvider.ts
@@ -12,11 +12,11 @@ export class RouteServiceProvider extends ServiceProvider {
         super(app.container);
     }
 
-    public register(): void {
+    public override register(): void {
         // Routes are registered during boot once the router is available.
     }
 
-    public boot(): void {
+    public override boot(): void {
         const router = this.app.make<Router>(ROUTER_KEY);
 
         router.get("/health", () =>

--- a/bootstrap/app.ts
+++ b/bootstrap/app.ts
@@ -4,6 +4,8 @@ import appConfig from "@/config/app";
 import { getDatabaseManager } from "./database";
 import { registerProviders } from "./providers";
 
+type AppServeOptions = Serve.Options<undefined> & { unix?: undefined };
+
 export { createServeOptions };
 
 /**
@@ -36,11 +38,11 @@ export async function bootstrap(): Promise<Application> {
  * @param app - Booted application instance
  * @returns Bun.serve configuration
  */
-export function createAppServeOptions(app: Application): Serve.Options<undefined> {
+export function createAppServeOptions(app: Application): AppServeOptions {
     return createServeOptions(app, {
         error(_error: Error): Response {
             return new Response("Internal Server Error", { status: 500 });
         },
         idleTimeout: 30,
-    });
+    }) as AppServeOptions;
 }

--- a/nino.ts
+++ b/nino.ts
@@ -18,8 +18,8 @@ import packageJson from "./package.json";
 const migrationsPath = path.join(process.cwd(), databaseConfig.migrations.directory);
 
 class HelpCommand extends Command {
-    protected signature = "help";
-    protected description = "Display available commands";
+    protected override signature = "help";
+    protected override description = "Display available commands";
 
     constructor(private readonly cli: Kernel) {
         super();
@@ -40,8 +40,8 @@ class HelpCommand extends Command {
 }
 
 class VersionCommand extends Command {
-    protected signature = "version";
-    protected description = "Show application and framework versions";
+    protected override signature = "version";
+    protected override description = "Show application and framework versions";
 
     public async handle(): Promise<number> {
         this.line(`ninots-app ${packageJson.version}`);
@@ -51,8 +51,8 @@ class VersionCommand extends Command {
 }
 
 class ServeCommand extends Command {
-    protected signature = "serve {--port=3000}";
-    protected description = "Start the HTTP development server";
+    protected override signature = "serve {--port=3000}";
+    protected override description = "Start the HTTP development server";
 
     public async handle(): Promise<number> {
         const app = await bootstrap();
@@ -80,8 +80,8 @@ class ServeCommand extends Command {
 }
 
 class RoutesCommand extends Command {
-    protected signature = "routes:list";
-    protected description = "List all registered routes";
+    protected override signature = "routes:list";
+    protected override description = "List all registered routes";
 
     public async handle(): Promise<number> {
         const app = await bootstrap();
@@ -99,8 +99,8 @@ class RoutesCommand extends Command {
 }
 
 class CacheClearCommand extends Command {
-    protected signature = "cache:clear";
-    protected description = "Clear the application cache";
+    protected override signature = "cache:clear";
+    protected override description = "Clear the application cache";
 
     public async handle(): Promise<number> {
         this.info("Cache cleared successfully");

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "start": "bun run nino.ts serve --prod",
         "build": "bun build --compile --bytecode nino.ts --outfile ninots",
         "nino": "bun run nino.ts",
+        "type-check": "tsc --noEmit",
         "docs:generate": "typedoc",
         "format": "bunx biome format --write .",
         "lint": "bunx biome check .",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
         "start": "bun run nino.ts serve --prod",
         "build": "bun build --compile --bytecode nino.ts --outfile ninots",
         "nino": "bun run nino.ts",
-        "type-check": "tsc --noEmit",
         "docs:generate": "typedoc",
         "format": "bunx biome format --write .",
         "lint": "bunx biome check .",

--- a/resources/views/welcome.tsx
+++ b/resources/views/welcome.tsx
@@ -1,5 +1,5 @@
 import { withLayout } from "@ninots/view";
-import { AppLayout } from "@/resources/views/layouts/app.tsx";
+import { AppLayout } from "@/resources/views/layouts/app";
 
 export interface WelcomeProps {
     subtitle?: string;

--- a/routes/api.ts
+++ b/routes/api.ts
@@ -9,9 +9,9 @@ export function registerApiRoutes(router: Router, app: Application): void {
 
     router.group({ prefix: "/api" }, () => {
         router.get("/users", () => users.list());
-        router.post("/users", (request) => users.create(request));
-        router.get("/users/:id", (request, params?: RouteParams) => users.show(request, params));
-        router.put("/users/:id", (request, params?: RouteParams) => users.update(request, params));
-        router.delete("/users/:id", (request, params?: RouteParams) => users.destroy(request, params));
+        router.post("/users", (request: Request) => users.create(request));
+        router.get("/users/:id", (request: Request, params?: RouteParams) => users.show(request, params));
+        router.put("/users/:id", (request: Request, params?: RouteParams) => users.update(request, params));
+        router.delete("/users/:id", (request: Request, params?: RouteParams) => users.destroy(request, params));
     });
 }

--- a/routes/web.ts
+++ b/routes/web.ts
@@ -1,6 +1,6 @@
 import { render } from "@ninots/view";
 import type { Router } from "@ninots/framework";
-import { Welcome } from "@/resources/views/welcome.tsx";
+import { Welcome } from "@/resources/views/welcome";
 
 /**
  * Web routes (HTML pages rendered via @ninots/view).

--- a/tests/Feature/WebRoute.test.ts
+++ b/tests/Feature/WebRoute.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { render } from "@ninots/view";
 import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
-import { Welcome } from "@/resources/views/welcome.tsx";
+import { Welcome } from "@/resources/views/welcome";
 
 describe("Web routes", () => {
     test("GET / returns rendered HTML welcome page", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
         "jsx": "react-jsx",
         "jsxImportSource": "@ninots/view",
         "allowJs": false,
+        "baseUrl": ".",
+        "ignoreDeprecations": "6.0",
         "types": ["bun"],
         // Bundler mode
         "moduleResolution": "bundler",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,11 +11,12 @@
         "types": ["bun"],
         // Bundler mode
         "moduleResolution": "bundler",
-        "allowImportingTsExtensions": true,
+        "allowImportingTsExtensions": false,
         "verbatimModuleSyntax": true,
         "noEmit": true,
         // Best practices
         "strict": true,
+        "noImplicitAny": true,
         "skipLibCheck": true,
         "noFallthroughCasesInSwitch": true,
         "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
## Summary
- Updates the starter tsconfig to disallow TS import extensions and explicitly enable noImplicitAny.
- Removes `.ts`/`.tsx` import specifiers from starter aliases.
- Adds explicit handler types and Response.json init objects needed by stricter checking.

## Test plan
- `bun test`
- `rg "biome-ignore|@ts-ignore|@ts-expect-error|eslint-disable" ninots/`
- `rg "from\\s+['\"].*\\.tsx?['\"]|import\\(['\"].*\\.tsx?['\"]\\)" ninots/`

Note: direct `tsc --noEmit` still traverses the linked raw framework package because `framework/dist` is not generated by the current build path; framework PR nino-ts/framework#26 contains the source hygiene side of that work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the users API with create, retrieve, update, and delete endpoints.
* **Bug Fixes**
  * Updated JSON responses to apply HTTP status codes consistently.
* **Improvements**
  * Strengthened TypeScript type checking across middleware, application setup, providers, and command definitions.
  * Simplified module imports for improved compatibility.
* **Tests**
  * Maintained web-route and security validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->