### PR TITLE
Sprint 5 Phase 1: contact POST demo + CSRF feature tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,5 +23,8 @@ CACHE_STORE=array
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
+# CSRF (set a strong secret in production)
+CSRF_SECRET=change-me-in-production
+
 # Queue (sync only — async drivers in a future sprint)
 QUEUE_CONNECTION=sync

--- a/app/Providers/AppServiceProvider.ts
+++ b/app/Providers/AppServiceProvider.ts
@@ -1,8 +1,9 @@
 import type { Application } from "@ninots/framework";
-import { EVENT_DISPATCHER_KEY, ServiceProvider } from "@ninots/framework";
-import type { EventDispatcher } from "@ninots/framework";
+import { EVENT_DISPATCHER_KEY, MIDDLEWARE_STACK_KEY, ServiceProvider, verifyCsrf } from "@ninots/framework";
+import type { EventDispatcher, MiddlewareStack } from "@ninots/framework";
 import { UsersController } from "@/app/Http/Controllers/UsersController";
 import { UserService } from "@/app/Services/UserService";
+import csrfConfig from "@/config/csrf";
 
 /**
  * Application service provider.
@@ -17,5 +18,19 @@ export class AppServiceProvider extends ServiceProvider {
 
         this.app.singleton(UserService.name, () => new UserService(events));
         this.app.singleton(UsersController.name, () => new UsersController(this.app.make(UserService.name)));
+    }
+
+    public override boot(): void {
+        const stack = this.app.make<MiddlewareStack>(MIDDLEWARE_STACK_KEY);
+
+        stack.add(
+            "csrf",
+            verifyCsrf({
+                secret: csrfConfig.secret,
+                sessionCookieName: csrfConfig.sessionCookie,
+                tokenFieldName: csrfConfig.tokenField,
+            }),
+        );
+        stack.alias("web", ["csrf"]);
     }
 }

--- a/config/csrf.ts
+++ b/config/csrf.ts
@@ -1,0 +1,5 @@
+export default {
+    secret: Bun.env.CSRF_SECRET ?? "ninots-dev-csrf-secret",
+    sessionCookie: Bun.env.CSRF_SESSION_COOKIE ?? "ninots_session",
+    tokenField: "_token",
+};

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "start": "bun run nino.ts serve --prod",
         "build": "bun build --compile --bytecode nino.ts --outfile ninots",
         "nino": "bun run nino.ts",
+        "type-check": "tsc --noEmit",
         "docs:generate": "typedoc",
         "format": "bunx biome format --write .",
         "lint": "bunx biome check .",

--- a/resources/views/contact-thanks.tsx
+++ b/resources/views/contact-thanks.tsx
@@ -1,0 +1,21 @@
+import { withLayout } from "@ninots/view";
+import { AppLayout } from "@/resources/views/layouts/app";
+
+export interface ContactThanksProps {
+    message?: string;
+}
+
+function ContactThanksPage({ message = "" }: ContactThanksProps) {
+    return (
+        <section className="welcome contact-form">
+            <h1>Thanks!</h1>
+            <p className="success-note">Your message was received.</p>
+            <blockquote className="message-preview">{message}</blockquote>
+            <p>
+                <a href="/contact">Send another message</a>
+            </p>
+        </section>
+    );
+}
+
+export const ContactThanks = withLayout(AppLayout, ContactThanksPage, { title: "Message sent — Ninots" });

--- a/resources/views/contact.tsx
+++ b/resources/views/contact.tsx
@@ -1,0 +1,27 @@
+import { withLayout, csrfField } from "@ninots/view";
+import { AppLayout } from "@/resources/views/layouts/app";
+
+export interface ContactFormProps {
+    csrfToken?: string;
+}
+
+function ContactFormPage({ csrfToken = "" }: ContactFormProps) {
+    return (
+        <section className="welcome contact-form">
+            <h1>Contact</h1>
+            <p>Send us a message — protected by CSRF middleware.</p>
+            <form method="post" action="/contact" className="stack-form">
+                <div dangerouslySetInnerHTML={{ __html: csrfField(csrfToken) }} />
+                <label className="field">
+                    <span className="field-label">Message</span>
+                    <textarea name="message" required rows={4} placeholder="Say hello..." />
+                </label>
+                <button type="submit" className="button-primary">
+                    Send message
+                </button>
+            </form>
+        </section>
+    );
+}
+
+export const ContactForm = withLayout(AppLayout, ContactFormPage, { title: "Contact — Ninots" });

--- a/resources/views/layouts/app.tsx
+++ b/resources/views/layouts/app.tsx
@@ -72,11 +72,79 @@ body {
     color: var(--accent);
 }
 
+.welcome a {
+    color: var(--accent);
+}
+
 .site-footer {
     padding: 1.5rem 0 2rem;
     border-top: 1px solid var(--border);
     color: var(--muted);
     font-size: 0.95rem;
+}
+
+.stack-form {
+    display: grid;
+    gap: 1.25rem;
+    margin-top: 1.5rem;
+}
+
+.field {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.field-label {
+    font-weight: 600;
+    color: var(--text);
+}
+
+.field textarea {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--bg) 70%, var(--surface));
+    color: var(--text);
+    font: inherit;
+    resize: vertical;
+}
+
+.field textarea:focus {
+    outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+    border-color: var(--accent);
+}
+
+.button-primary {
+    justify-self: start;
+    padding: 0.65rem 1.25rem;
+    border: none;
+    border-radius: 0.5rem;
+    background: linear-gradient(135deg, var(--accent), #0ea5e9);
+    color: #0f172a;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.button-primary:hover {
+    filter: brightness(1.05);
+}
+
+.success-note {
+    color: #86efac;
+    font-weight: 600;
+}
+
+.message-preview {
+    margin: 1rem 0 0;
+    padding: 1rem 1.25rem;
+    border-left: 4px solid var(--accent);
+    background: color-mix(in srgb, var(--surface) 90%, transparent);
+    color: var(--text);
+}
+
+.contact-form a {
+    color: var(--accent);
 }
 `;
 

--- a/resources/views/welcome.tsx
+++ b/resources/views/welcome.tsx
@@ -10,7 +10,8 @@ function WelcomePage({ subtitle = "Your application is ready. Start building in 
         <section className="welcome">
             <h1>Welcome to Ninots</h1>
             <p>
-                {subtitle} Explore <strong>api</strong>, <strong>web</strong>, and <strong>websocket</strong> surfaces.
+                {subtitle} Explore <strong>api</strong>, <strong>web</strong>, and <strong>websocket</strong> surfaces. Try the{" "}
+                <a href="/contact">contact form</a>.
             </p>
         </section>
     );

--- a/routes/web.ts
+++ b/routes/web.ts
@@ -1,14 +1,51 @@
+import {
+    generateCsrfToken,
+    resolveCsrfConfig,
+    resolveSessionId,
+    withSessionCookie,
+} from "@ninots/framework";
 import { render } from "@ninots/view";
 import type { Router } from "@ninots/framework";
 import { Welcome } from "@/resources/views/welcome";
+import { ContactForm } from "@/resources/views/contact";
+import { ContactThanks } from "@/resources/views/contact-thanks";
+import csrfConfig from "@/config/csrf";
+
+const csrfOptions = {
+    secret: csrfConfig.secret,
+    sessionCookieName: csrfConfig.sessionCookie,
+    tokenFieldName: csrfConfig.tokenField,
+};
+
+function getCsrfConfig() {
+    return resolveCsrfConfig(csrfOptions);
+}
 
 /**
  * Web routes (HTML pages rendered via @ninots/view).
  */
 export function registerWebRoutes(router: Router): void {
-    router.get("/", () =>
-        render(Welcome, {
-            subtitle: "Laravel-like DX on Bun.",
-        }),
-    );
+    router.group({ middleware: ["web"] }, () => {
+        router.get("/", () =>
+            render(Welcome, {
+                subtitle: "Laravel-like DX on Bun.",
+            }),
+        );
+
+        router.get("/contact", async (request) => {
+            const config = getCsrfConfig();
+            const session = resolveSessionId(request, config.sessionCookieName);
+            const token = generateCsrfToken(session.sessionId, config);
+            const response = await render(ContactForm, { csrfToken: token });
+
+            return withSessionCookie(response, session, config.sessionCookieName);
+        });
+
+        router.post("/contact", async (request) => {
+            const formData = await request.formData();
+            const message = String(formData.get("message") ?? "").trim();
+
+            return render(ContactThanks, { message: message || "(empty message)" });
+        });
+    });
 }

--- a/tests/Feature/CsrfContact.test.ts
+++ b/tests/Feature/CsrfContact.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
+
+const SESSION_COOKIE = "ninots_session";
+
+function extractCookie(setCookieHeader: string | null, name: string): string | undefined {
+    if (!setCookieHeader) {
+        return undefined;
+    }
+
+    const match = setCookieHeader.match(new RegExp(`${name}=([^;]+)`));
+    return match?.[1] ? decodeURIComponent(match[1]) : undefined;
+}
+
+function extractCsrfToken(html: string): string | undefined {
+    const match = html.match(/name="_token"\s+value="([^"]+)"/);
+    return match?.[1];
+}
+
+describe("CSRF contact form", () => {
+    test("GET /contact returns a form with CSRF hidden field", async () => {
+        const app = await bootstrap();
+        const server = Bun.serve({
+            ...createAppServeOptions(app),
+            port: 0,
+            hostname: "127.0.0.1",
+        });
+
+        try {
+            const response = await fetch(`http://127.0.0.1:${server.port}/contact`);
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get("Content-Type")).toContain("text/html");
+
+            const html = await response.text();
+            expect(html).toContain('name="_token"');
+            expect(html).toContain('method="post"');
+            expect(html).toContain("Contact");
+        } finally {
+            server.stop();
+        }
+    });
+
+    test("POST /contact without CSRF token is rejected", async () => {
+        const app = await bootstrap();
+        const server = Bun.serve({
+            ...createAppServeOptions(app),
+            port: 0,
+            hostname: "127.0.0.1",
+        });
+
+        try {
+            const response = await fetch(`http://127.0.0.1:${server.port}/contact`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    Cookie: `${SESSION_COOKIE}=test-session-without-token`,
+                },
+                body: "message=hello",
+            });
+
+            expect(response.status).toBe(419);
+        } finally {
+            server.stop();
+        }
+    });
+
+    test("POST /contact with valid CSRF token is accepted", async () => {
+        const app = await bootstrap();
+        const server = Bun.serve({
+            ...createAppServeOptions(app),
+            port: 0,
+            hostname: "127.0.0.1",
+        });
+
+        try {
+            const baseUrl = `http://127.0.0.1:${server.port}`;
+            const getResponse = await fetch(`${baseUrl}/contact`);
+            const html = await getResponse.text();
+            const token = extractCsrfToken(html);
+
+            expect(token).toBeDefined();
+
+            const setCookie = getResponse.headers.get("set-cookie");
+            const sessionId = extractCookie(setCookie, SESSION_COOKIE);
+            expect(sessionId).toBeDefined();
+
+            const postResponse = await fetch(`${baseUrl}/contact`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    Cookie: `${SESSION_COOKIE}=${encodeURIComponent(sessionId ?? "")}`,
+                },
+                body: `_token=${encodeURIComponent(token ?? "")}&message=Hello+from+CSRF+test`,
+            });
+
+            expect(postResponse.status).toBe(200);
+
+            const thanksHtml = await postResponse.text();
+            expect(thanksHtml).toContain("Thanks!");
+            expect(thanksHtml).toContain("Hello from CSRF test");
+        } finally {
+            server.stop();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Wire \web\ middleware group with \erifyCsrf\ in AppServiceProvider
- Add GET/POST \/contact\ demo with \csrfField()\ hidden input and thanks page
- Feature tests: reject POST without token; accept with valid token

Fixes #16

Depends on framework PR (CSRF middleware + csrfField)

## Test plan
- [x] \un test tests/Feature/CsrfContact.test.ts\
- [x] \un test\ (11 pass)
- [ ] Ivy QA sign-off

Made with [Cursor](https://cursor.com)