### PR TITLE
fix(ts): green type-check with linked framework (Fixes #19)

### DIFF
--- a/app/Providers/RouteServiceProvider.ts
+++ b/app/Providers/RouteServiceProvider.ts
@@ -8,8 +8,11 @@ import { registerWebRoutes } from "@/routes/web";
  * Route service provider — single source of truth for HTTP routes.
  */
 export class RouteServiceProvider extends ServiceProvider {
+    private readonly application: Application;
+
     constructor(app: Application) {
         super(app.container);
+        this.application = app;
     }
 
     public override register(): void {
@@ -27,6 +30,6 @@ export class RouteServiceProvider extends ServiceProvider {
         );
 
         registerWebRoutes(router);
-        registerApiRoutes(router, this.app);
+        registerApiRoutes(router, this.application);
     }
 }

--- a/app/Services/UserService.ts
+++ b/app/Services/UserService.ts
@@ -9,7 +9,8 @@ export class UserService {
     constructor(private readonly events: EventDispatcher) {}
 
     public async all(): Promise<User[]> {
-        return User.all();
+        const users = await User.all();
+        return users.all();
     }
 
     public async find(id: number): Promise<User | null> {
@@ -20,7 +21,9 @@ export class UserService {
         const user = new User();
         user.fill(data);
         await user.save();
-        await this.events.dispatch(new UserCreatedEvent(user.id, user.email));
+        const userId = Number(user.getAttribute("id"));
+        const email = String(user.getAttribute("email") ?? "");
+        await this.events.dispatch(new UserCreatedEvent(userId, email));
         return user;
     }
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "ninots-app",
       "dependencies": {
         "@ninots/framework": "link:@ninots/framework",
+        "@ninots/view": "link:@ninots/view",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.14",
@@ -34,6 +35,8 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.14", "", { "os": "win32", "cpu": "x64" }, "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA=="],
 
     "@ninots/framework": ["@ninots/framework@link:@ninots/framework", { "bin": { "nino": "./nino" } }],
+
+    "@ninots/view": ["@ninots/view@link:@ninots/view", {}],
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 

--- a/config/database.ts
+++ b/config/database.ts
@@ -1,35 +1,41 @@
+import type { ConnectionConfig, DatabaseDriver } from "@ninots/framework";
+
+type DatabaseConnections = Record<string, ConnectionConfig>;
+
+const connections = {
+    sqlite: {
+        driver: "sqlite",
+        filename: "storage/database.sqlite",
+        foreignKeys: true,
+    },
+    postgres: {
+        driver: "postgres",
+        host: Bun.env.DB_HOST ?? "127.0.0.1",
+        port: parseInt(Bun.env.DB_PORT ?? "5432", 10),
+        database: Bun.env.DB_DATABASE ?? "ninots",
+        username: Bun.env.DB_USERNAME ?? "root",
+        password: Bun.env.DB_PASSWORD ?? "",
+    },
+    mysql: {
+        driver: "mysql",
+        host: Bun.env.DB_HOST ?? "127.0.0.1",
+        port: parseInt(Bun.env.DB_PORT ?? "3306", 10),
+        database: Bun.env.DB_DATABASE ?? "ninots",
+        username: Bun.env.DB_USERNAME ?? "root",
+        password: Bun.env.DB_PASSWORD ?? "",
+    },
+} as const satisfies DatabaseConnections;
+
 export default {
     /**
      * Default database connection
      */
-    default: Bun.env.DB_CONNECTION ?? "sqlite",
+    default: (Bun.env.DB_CONNECTION ?? "sqlite") as DatabaseDriver | string,
 
     /**
      * Database connections
      */
-    connections: {
-        sqlite: {
-            driver: "sqlite",
-            filename: "storage/database.sqlite",
-            foreignKeys: true,
-        },
-        postgres: {
-            driver: "postgres",
-            host: Bun.env.DB_HOST ?? "127.0.0.1",
-            port: parseInt(Bun.env.DB_PORT ?? "5432", 10),
-            database: Bun.env.DB_DATABASE ?? "ninots",
-            username: Bun.env.DB_USERNAME ?? "root",
-            password: Bun.env.DB_PASSWORD ?? "",
-        },
-        mysql: {
-            driver: "mysql",
-            host: Bun.env.DB_HOST ?? "127.0.0.1",
-            port: parseInt(Bun.env.DB_PORT ?? "3306", 10),
-            database: Bun.env.DB_DATABASE ?? "ninots",
-            username: Bun.env.DB_USERNAME ?? "root",
-            password: Bun.env.DB_PASSWORD ?? "",
-        },
-    },
+    connections,
 
     /**
      * Migration configuration


### PR DESCRIPTION
## Summary
- Fix starter type errors uncovered once framework exports resolve to `.d.ts` (Application wiring, `Collection` unwrap, `ConnectionConfig` drivers).
- Lockfile includes `@ninots/view` link used by JSX.
- **Fixes #19**

Depends on companion framework PR https://github.com/nino-ts/framework/pull/32 (declaration boundary). Prefer **regular merge** after framework lands (or merge both with framework first).

## Test plan
- [x] `bun run type-check` → exit 0 (was 124 errors)
- [x] `bun test` — 11 pass, 0 fail
- [ ] QA re-run sign-off gate after merge + `bun link`

Made with [Cursor](https://cursor.com)