### PR TITLE
fix: CLI entry nino wrapper + bootstrap/cli.ts (Fixes #21)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,7 @@
 
 ## High-level architecture
 
-- **Runtime shape:** This is a Bun + Ninots app. Entry point is `src/nino.ts`, which defines CLI commands through `@ninots/console` (`serve`, `routes:list`, `cache:clear`).
+- **Runtime shape:** This is a Bun + Ninots app. Entry point is `nino` (wrapper → `bootstrap/cli.ts`), which defines CLI commands through `@ninots/console` (`serve`, `routes:list`, `cache:clear`).
 - **Boot flow:** `serve` calls `bootstrap()` from `src/bootstrap/app.ts`:
   1. create DI container (`createContainer`)
   2. create `Application`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bun run nino --help
 
 | Command | Description |
 | --- | --- |
-| `bun run dev` | Runs `src/nino.ts serve` with hot reload |
+| `bun run dev` | Runs `nino serve` with hot reload |
 | `bun run start` | Starts server in production mode |
 | `bun run build` | Builds a compiled binary (`ninots`) |
 | `bun run nino --help` | Lists CLI commands |
@@ -59,7 +59,7 @@ bun run nino --help
 
 ### Boot Flow
 
-`src/nino.ts` is the CLI entrypoint. The `serve` command:
+`nino` (wrapper → `bootstrap/cli.ts`) is the CLI entrypoint. The `serve` command:
 
 1. Calls `bootstrap()` from `src/bootstrap/app.ts`
 2. Creates container + application instance
@@ -99,7 +99,7 @@ src/
   modules/        # domain modules (users, posts, payments, notifications, ...)
   routes/         # route groups: (api), (web), (ws)
   shared/         # shared providers and HTTP middleware
-  nino.ts         # CLI entrypoint
+  nino            # CLI entrypoint (→ bootstrap/cli.ts)
 tests/
   setup.ts        # Bun test preload setup
 ```

--- a/bootstrap/cli.ts
+++ b/bootstrap/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env bun
 import path from "node:path";
 import {
     Command,
@@ -13,7 +14,7 @@ import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
 import { getDatabaseManager } from "@/bootstrap/database";
 import databaseConfig from "@/config/database";
 import { DatabaseSeeder } from "@/database/seeders/DatabaseSeeder";
-import packageJson from "./package.json";
+import packageJson from "../package.json";
 
 const migrationsPath = path.join(process.cwd(), databaseConfig.migrations.directory);
 

--- a/nino
+++ b/nino
@@ -1,0 +1,2 @@
+#!/usr/bin/env bun
+import "./bootstrap/cli.ts";

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
     "version": "0.4.0",
     "private": true,
     "type": "module",
+    "bin": {
+        "nino": "./nino"
+    },
     "scripts": {
-        "dev": "bun run --hot nino.ts serve",
-        "start": "bun run nino.ts serve --prod",
-        "build": "bun build --compile --bytecode nino.ts --outfile ninots",
-        "nino": "bun run nino.ts",
+        "dev": "bun --hot ./nino serve",
+        "start": "bun ./nino serve --prod",
+        "build": "bun build --compile --bytecode ./nino --outfile ninots",
+        "nino": "bun ./nino",
         "type-check": "tsc --noEmit",
         "docs:generate": "typedoc",
         "format": "bunx biome format --write .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,6 @@
         "jsx": "react-jsx",
         "jsxImportSource": "@ninots/view",
         "allowJs": false,
-        "baseUrl": ".",
-        "ignoreDeprecations": "6.0",
         "types": ["bun"],
         // Bundler mode
         "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- Add root `nino` shebang wrapper (`framework/nino` pattern) importing `bootstrap/cli.ts`
- Move CLI logic from `nino.ts` to `bootstrap/cli.ts`; remove `nino.ts`
- Update `package.json` `bin` + scripts to invoke `./nino` (disambiguates from linked `@ninots/framework` bin)
- Update README and copilot-instructions

## Test plan
- [x] `bun run nino help` — lists serve, migrate, db:seed, etc.
- [x] `bun test` — 11/11 pass
- [x] `bun run type-check` — exit 0
- [x] Zero `nino.ts` references in starter scripts/docs

Made with [Cursor](https://cursor.com)