### PR TITLE
Sprint 6: wire make:* generators + feature tests

### DIFF
--- a/bootstrap/cli.ts
+++ b/bootstrap/cli.ts
@@ -4,6 +4,10 @@ import {
     Command,
     DbSeedCommand,
     Kernel,
+    MakeControllerCommand,
+    MakeMigrationCommand,
+    MakeModelCommand,
+    MakeViewCommand,
     MigrateCommand,
     Migrator,
     ROUTER_KEY,
@@ -141,6 +145,13 @@ kernel.register(
         },
     }),
 );
+
+const generatorPaths = { basePath: process.cwd() };
+
+kernel.register(new MakeControllerCommand({ paths: generatorPaths }));
+kernel.register(new MakeModelCommand({ paths: generatorPaths }));
+kernel.register(new MakeMigrationCommand({ paths: generatorPaths }));
+kernel.register(new MakeViewCommand({ paths: generatorPaths }));
 
 const exitCode = await kernel.run(process.argv.slice(2));
 process.exit(exitCode);

--- a/routes/api.ts
+++ b/routes/api.ts
@@ -5,7 +5,9 @@ import { UsersController } from "@/app/Http/Controllers/UsersController";
  * API routes.
  */
 export function registerApiRoutes(router: Router, app: Application): void {
+    // -- nino:api-bindings --
     const users = app.make<UsersController>(UsersController.name);
+    // -- nino:api-imports --
 
     router.group({ prefix: "/api" }, () => {
         router.get("/users", () => users.list());
@@ -13,5 +15,7 @@ export function registerApiRoutes(router: Router, app: Application): void {
         router.get("/users/:id", (request: Request, params?: RouteParams) => users.show(request, params));
         router.put("/users/:id", (request: Request, params?: RouteParams) => users.update(request, params));
         router.delete("/users/:id", (request: Request, params?: RouteParams) => users.destroy(request, params));
+
+        // -- nino:api-routes --
     });
 }

--- a/routes/web.ts
+++ b/routes/web.ts
@@ -25,7 +25,9 @@ function getCsrfConfig() {
  * Web routes (HTML pages rendered via @ninots/view).
  */
 export function registerWebRoutes(router: Router): void {
+    // -- nino:web-imports --
     router.group({ middleware: ["web"] }, () => {
+        // -- nino:web-bindings --
         router.get("/", () =>
             render(Welcome, {
                 subtitle: "Laravel-like DX on Bun.",
@@ -47,5 +49,7 @@ export function registerWebRoutes(router: Router): void {
 
             return render(ContactThanks, { message: message || "(empty message)" });
         });
+
+        // -- nino:web-routes --
     });
 }

--- a/tests/Feature/MakeGenerator.test.ts
+++ b/tests/Feature/MakeGenerator.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
+import {
+    Kernel,
+    MakeControllerCommand,
+    Router,
+    ROUTER_KEY,
+} from "@ninots/framework";
+import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
+
+const SESSION_COOKIE = "ninots_session";
+
+async function createGeneratorWorkspace(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "ninots-starter-generator-"));
+
+    await mkdir(join(root, "app/Http/Controllers"), { recursive: true });
+    await mkdir(join(root, "routes"), { recursive: true });
+
+    await writeFile(
+        join(root, "routes/web.ts"),
+        `import type { Router } from "@ninots/framework";
+
+export function registerWebRoutes(router: Router): void {
+    // -- nino:web-imports --
+    router.group({ middleware: ["web"] }, () => {
+        // -- nino:web-bindings --
+        // -- nino:web-routes --
+    });
+}
+`,
+    );
+
+    return root;
+}
+
+describe("nino make:* generators", () => {
+    let root = "";
+
+    beforeEach(async () => {
+        root = await createGeneratorWorkspace();
+    });
+
+    afterEach(async () => {
+        await rm(root, { force: true, recursive: true });
+    });
+
+    test("kernel exposes make:controller command", async () => {
+        const kernel = new Kernel();
+        kernel.register(new MakeControllerCommand({ paths: { basePath: root } }));
+
+        const command = kernel.findCommand("make:controller");
+        expect(command).toBeDefined();
+        expect(command?.getDefinition().description).toContain("controller");
+    });
+
+    test("make:controller --resource generates controller and web POST route", async () => {
+        const kernel = new Kernel();
+        kernel.register(new MakeControllerCommand({ paths: { basePath: root } }));
+
+        const exitCode = await kernel.run(["make:controller", "ArticleController", "--resource"]);
+
+        expect(exitCode).toBe(0);
+        expect(existsSync(join(root, "app/Http/Controllers/ArticleController.ts"))).toBe(true);
+
+        const routes = await readFile(join(root, "routes/web.ts"), "utf8");
+        expect(routes).toContain('router.post("/articles"');
+        expect(routes).toContain('middleware: ["web"]');
+    });
+
+    test("resource-style web POST routes are CSRF-protected", async () => {
+        const app = await bootstrap();
+        const router = app.make<Router>(ROUTER_KEY);
+
+        router.group({ middleware: ["web"] }, () => {
+            router.post("/generated-resource", () => Response.json({ created: true }));
+        });
+
+        const server = Bun.serve({
+            ...createAppServeOptions(app),
+            port: 0,
+            hostname: "127.0.0.1",
+        });
+
+        try {
+            const response = await fetch(`http://127.0.0.1:${server.port}/generated-resource`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    Cookie: `${SESSION_COOKIE}=generator-session`,
+                },
+                body: "title=test",
+            });
+
+            expect(response.status).toBe(419);
+        } finally {
+            server.stop();
+        }
+    });
+
+    test("starter CLI help lists make:* commands", async () => {
+        const { spawnSync } = await import("node:child_process");
+        const result = spawnSync("bun", ["./nino", "help"], {
+            cwd: join(import.meta.dir, "../.."),
+            encoding: "utf8",
+        });
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain("make:controller");
+        expect(result.stdout).toContain("make:model");
+        expect(result.stdout).toContain("make:migration");
+        expect(result.stdout).toContain("make:view");
+    });
+});
+
+describe("starter web routes", () => {
+    test("GET / still renders after route marker changes", async () => {
+        const app = await bootstrap();
+        const server = Bun.serve({
+            ...createAppServeOptions(app),
+            port: 0,
+            hostname: "127.0.0.1",
+        });
+
+        try {
+            const response = await fetch(`http://127.0.0.1:${server.port}/`);
+            expect(response.status).toBe(200);
+        } finally {
+            server.stop();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Register make:controller/model/migration/view in bootstrap/cli.ts Kernel
- Add nino route markers in routes/web.ts and routes/api.ts for generator patching
- Feature tests: generator output, CLI help, CSRF 419 on web-group POST

## Test plan
- [x] bun test (16 pass)
- [x] bun run type-check
- [x] bun ./nino help lists make:* commands

Depends on framework PR for @ninots/framework exports.

Fixes #22, #23


Made with [Cursor](https://cursor.com)