### PR TITLE
fix(routes): top-level generator import markers (framework#42)

### DIFF
--- a/routes/api.ts
+++ b/routes/api.ts
@@ -1,13 +1,14 @@
 import type { Application, Router, RouteParams } from "@ninots/framework";
 import { UsersController } from "@/app/Http/Controllers/UsersController";
 
+// -- nino:api-imports --
+
 /**
  * API routes.
  */
 export function registerApiRoutes(router: Router, app: Application): void {
     // -- nino:api-bindings --
     const users = app.make<UsersController>(UsersController.name);
-    // -- nino:api-imports --
 
     router.group({ prefix: "/api" }, () => {
         router.get("/users", () => users.list());

--- a/routes/web.ts
+++ b/routes/web.ts
@@ -11,6 +11,8 @@ import { ContactForm } from "@/resources/views/contact";
 import { ContactThanks } from "@/resources/views/contact-thanks";
 import csrfConfig from "@/config/csrf";
 
+// -- nino:web-imports --
+
 const csrfOptions = {
     secret: csrfConfig.secret,
     sessionCookieName: csrfConfig.sessionCookie,
@@ -25,7 +27,6 @@ function getCsrfConfig() {
  * Web routes (HTML pages rendered via @ninots/view).
  */
 export function registerWebRoutes(router: Router): void {
-    // -- nino:web-imports --
     router.group({ middleware: ["web"] }, () => {
         // -- nino:web-bindings --
         router.get("/", () =>

--- a/tests/Feature/MakeGenerator.test.ts
+++ b/tests/Feature/MakeGenerator.test.ts
@@ -17,14 +17,16 @@ async function createGeneratorWorkspace(): Promise<string> {
     const root = await mkdtemp(join(tmpdir(), "ninots-starter-generator-"));
 
     await mkdir(join(root, "app/Http/Controllers"), { recursive: true });
+    await mkdir(join(root, "resources/views"), { recursive: true });
     await mkdir(join(root, "routes"), { recursive: true });
 
     await writeFile(
         join(root, "routes/web.ts"),
         `import type { Router } from "@ninots/framework";
 
+// -- nino:web-imports --
+
 export function registerWebRoutes(router: Router): void {
-    // -- nino:web-imports --
     router.group({ middleware: ["web"] }, () => {
         // -- nino:web-bindings --
         // -- nino:web-routes --
@@ -64,10 +66,52 @@ describe("nino make:* generators", () => {
 
         expect(exitCode).toBe(0);
         expect(existsSync(join(root, "app/Http/Controllers/ArticleController.ts"))).toBe(true);
+        expect(existsSync(join(root, "resources/views/articles.tsx"))).toBe(true);
 
         const routes = await readFile(join(root, "routes/web.ts"), "utf8");
         expect(routes).toContain('router.post("/articles"');
         expect(routes).toContain('middleware: ["web"]');
+
+        const importLine = routes
+            .split("\n")
+            .find((line) => line.includes("ArticleController") && line.trimStart().startsWith("import "));
+        expect(importLine?.startsWith("import ")).toBe(true);
+        expect(routes.indexOf("import { ArticleController }")).toBeLessThan(
+            routes.indexOf("export function registerWebRoutes"),
+        );
+    });
+
+    test("make:controller --resource keeps import top-level with legacy indented marker", async () => {
+        await writeFile(
+            join(root, "routes/web.ts"),
+            `import type { Router } from "@ninots/framework";
+
+export function registerWebRoutes(router: Router): void {
+    // -- nino:web-imports --
+    router.group({ middleware: ["web"] }, () => {
+        // -- nino:web-bindings --
+        // -- nino:web-routes --
+    });
+}
+`,
+        );
+
+        const kernel = new Kernel();
+        kernel.register(new MakeControllerCommand({ paths: { basePath: root } }));
+
+        const exitCode = await kernel.run(["make:controller", "LegacyController", "--resource"]);
+
+        expect(exitCode).toBe(0);
+
+        const routes = await readFile(join(root, "routes/web.ts"), "utf8");
+        const importLine = routes
+            .split("\n")
+            .find((line) => line.includes("LegacyController") && line.trimStart().startsWith("import "));
+
+        expect(importLine?.startsWith("import ")).toBe(true);
+        expect(routes.indexOf("import { LegacyController }")).toBeLessThan(
+            routes.indexOf("export function registerWebRoutes"),
+        );
     });
 
     test("resource-style web POST routes are CSRF-protected", async () => {


### PR DESCRIPTION
## Summary
- Move `// -- nino:web-imports --` / `// -- nino:api-imports --` to true top-level in starter routes
- Feature tests assert `--resource` imports stay before `export function registerWebRoutes` (including legacy indented markers via linked framework fix)

## Test plan
- [x] `bun test tests/Feature/MakeGenerator.test.ts` (6/6) with linked framework fix branch
- [x] `bun ./nino make:controller Post --resource` + `bun run type-check` exit 0
- [ ] Merge after [framework PR](https://github.com/nino-ts/framework/pulls) for #42

Pairs with nino-ts/framework#42