### PR TITLE
feat(cli): wire migrate:rollback + migrate:refresh (Sprint 7)

### DIFF
--- a/bootstrap/cli.ts
+++ b/bootstrap/cli.ts
@@ -9,6 +9,8 @@ import {
     MakeModelCommand,
     MakeViewCommand,
     MigrateCommand,
+    MigrateRefreshCommand,
+    MigrateRollbackCommand,
     Migrator,
     ROUTER_KEY,
     SeederRunner,
@@ -21,6 +23,20 @@ import { DatabaseSeeder } from "@/database/seeders/DatabaseSeeder";
 import packageJson from "../package.json";
 
 const migrationsPath = path.join(process.cwd(), databaseConfig.migrations.directory);
+
+function resolveMigrator(): Migrator {
+    getDatabaseManager();
+    return new Migrator({
+        database: getDatabaseManager(),
+        path: migrationsPath,
+        table: databaseConfig.migrations.table,
+    });
+}
+
+function resolveSeederRunner(): SeederRunner {
+    getDatabaseManager();
+    return new SeederRunner(DatabaseSeeder);
+}
 
 class HelpCommand extends Command {
     protected override signature = "help";
@@ -37,7 +53,7 @@ class HelpCommand extends Command {
 
         for (const command of this.cli.getCommands()) {
             const definition = command.getDefinition();
-            this.line(`  ${definition.name.padEnd(16)} ${definition.description}`);
+            this.line(`  ${definition.name.padEnd(20)} ${definition.description}`);
         }
 
         return 0;
@@ -127,22 +143,23 @@ kernel.register(new RoutesCommand());
 kernel.register(new CacheClearCommand());
 kernel.register(
     new MigrateCommand({
-        resolveMigrator: () => {
-            getDatabaseManager();
-            return new Migrator({
-                database: getDatabaseManager(),
-                path: migrationsPath,
-                table: databaseConfig.migrations.table,
-            });
-        },
+        resolveMigrator,
+    }),
+);
+kernel.register(
+    new MigrateRollbackCommand({
+        resolveMigrator,
+    }),
+);
+kernel.register(
+    new MigrateRefreshCommand({
+        resolveMigrator,
+        resolveSeederRunner,
     }),
 );
 kernel.register(
     new DbSeedCommand({
-        resolveSeederRunner: () => {
-            getDatabaseManager();
-            return new SeederRunner(DatabaseSeeder);
-        },
+        resolveSeederRunner,
     }),
 );
 

--- a/tests/Feature/MigrateLifecycle.test.ts
+++ b/tests/Feature/MigrateLifecycle.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import path from "node:path";
+import {
+    Kernel,
+    MigrateCommand,
+    MigrateRefreshCommand,
+    MigrateRollbackCommand,
+    Migrator,
+} from "@ninots/framework";
+import databaseConfig from "@/config/database";
+import { setupTestDatabase, teardownTestDatabase } from "@/tests/support/database";
+
+const migrationsPath = path.join(process.cwd(), databaseConfig.migrations.directory);
+
+function createMigrateKernel(migrator: Migrator): Kernel {
+    const kernel = new Kernel();
+    kernel.setOutput({
+        writeLine(_text: string): void {},
+    });
+    kernel.register(new MigrateCommand({ resolveMigrator: () => migrator }));
+    kernel.register(new MigrateRollbackCommand({ resolveMigrator: () => migrator }));
+    kernel.register(new MigrateRefreshCommand({ resolveMigrator: () => migrator }));
+    return kernel;
+}
+
+describe("migrate lifecycle (rollback + refresh)", () => {
+    afterEach(async () => {
+        await teardownTestDatabase();
+    });
+
+    test("kernel registers migrate:rollback and migrate:refresh", () => {
+        const kernel = new Kernel();
+        kernel.register(
+            new MigrateRollbackCommand({
+                resolveMigrator: () => {
+                    throw new Error("resolveMigrator should not run for registration checks");
+                },
+            }),
+        );
+        kernel.register(
+            new MigrateRefreshCommand({
+                resolveMigrator: () => {
+                    throw new Error("resolveMigrator should not run for registration checks");
+                },
+            }),
+        );
+
+        expect(kernel.findCommand("migrate:rollback")?.getDefinition().name).toBe("migrate:rollback");
+        expect(kernel.findCommand("migrate:refresh")?.getDefinition().name).toBe("migrate:refresh");
+        expect(kernel.findCommand("migrate:rollback")?.getDefinition().description).toContain("Rollback");
+        expect(kernel.findCommand("migrate:refresh")?.getDefinition().description).toContain("Reset");
+    });
+
+    test("migrate then rollback reverts the last batch", async () => {
+        const database = await setupTestDatabase();
+        const migrator = new Migrator({
+            database,
+            path: migrationsPath,
+            table: databaseConfig.migrations.table,
+        });
+
+        const tablesBefore = await database
+            .connection()
+            .query<{ name: string }>("SELECT name FROM sqlite_master WHERE type = 'table'");
+        expect(tablesBefore.map((row) => row.name)).toContain("users");
+
+        const kernel = createMigrateKernel(migrator);
+        const exitCode = await kernel.run(["migrate:rollback"]);
+
+        expect(exitCode).toBe(0);
+
+        const tablesAfter = await database
+            .connection()
+            .query<{ name: string }>("SELECT name FROM sqlite_master WHERE type = 'table'");
+        expect(tablesAfter.map((row) => row.name)).not.toContain("users");
+        expect(await migrator.getLastBatchNumber()).toBe(0);
+    });
+
+    test("migrate:refresh restores a clean post-migrate schema", async () => {
+        const database = await setupTestDatabase();
+        await database.connection().run(
+            "INSERT INTO users (email, name, password) VALUES ('stale@ninots.test', 'Stale', 'secret')",
+        );
+
+        const migrator = new Migrator({
+            database,
+            path: migrationsPath,
+            table: databaseConfig.migrations.table,
+        });
+        const kernel = createMigrateKernel(migrator);
+
+        const exitCode = await kernel.run(["migrate:refresh"]);
+        expect(exitCode).toBe(0);
+
+        const rows = await database.connection().query<{ email: string }>("SELECT email FROM users");
+        expect(rows).toHaveLength(0);
+        expect(await migrator.getLastBatchNumber()).toBe(1);
+
+        const tables = await database
+            .connection()
+            .query<{ name: string }>("SELECT name FROM sqlite_master WHERE type = 'table'");
+        expect(tables.map((row) => row.name)).toContain("users");
+    });
+
+    test("migrate:rollback with --step=1 reverts a single migration", async () => {
+        const database = await setupTestDatabase();
+        const migrator = new Migrator({
+            database,
+            path: migrationsPath,
+            table: databaseConfig.migrations.table,
+        });
+        const kernel = createMigrateKernel(migrator);
+
+        const exitCode = await kernel.run(["migrate:rollback", "--step=1"]);
+        expect(exitCode).toBe(0);
+
+        const tables = await database
+            .connection()
+            .query<{ name: string }>("SELECT name FROM sqlite_master WHERE type = 'table'");
+        expect(tables.map((row) => row.name)).not.toContain("users");
+    });
+});
+
+describe("CLI bootstrap registers migrate lifecycle commands", () => {
+    test("nino help lists migrate:rollback and migrate:refresh", async () => {
+        const proc = Bun.spawn(["bun", "./nino", "help"], {
+            cwd: process.cwd(),
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        const stdout = await new Response(proc.stdout).text();
+        const exitCode = await proc.exited;
+
+        expect(exitCode).toBe(0);
+        expect(stdout).toContain("migrate:rollback");
+        expect(stdout).toContain("migrate:refresh");
+    });
+});


### PR DESCRIPTION
## Summary
- Register `migrate:rollback` and `migrate:refresh` in `bootstrap/cli.ts`
- Feature tests for rollback, refresh, `--step`, and `nino help` listing

## Issues
Fixes #27, Fixes #28

## Depends on
Companion framework PR: https://github.com/nino-ts/framework/pull/50

## Test plan
- [x] `bun test tests/Feature/MigrateLifecycle.test.ts` (5 pass)
- [x] Full suite `bun test` (22 pass)
- [x] `bun run type-check`
- [ ] Ivy QA sign-off
- [ ] Regular merge only (no squash/rebase)

## Notes
Requires linked/`@ninots/framework` with Sprint 7 Migrator APIs.