### PR TITLE
[Sprint 9] Wire Wide Events middleware + smoke (1 canonical line)

### DIFF
--- a/app/Providers/AppServiceProvider.ts
+++ b/app/Providers/AppServiceProvider.ts
@@ -1,5 +1,11 @@
 import type { Application } from "@ninots/framework";
-import { EVENT_DISPATCHER_KEY, MIDDLEWARE_STACK_KEY, ServiceProvider, verifyCsrf } from "@ninots/framework";
+import {
+    EVENT_DISPATCHER_KEY,
+    MIDDLEWARE_STACK_KEY,
+    ServiceProvider,
+    verifyCsrf,
+    wideEventMiddleware,
+} from "@ninots/framework";
 import type { EventDispatcher, MiddlewareStack } from "@ninots/framework";
 import { UsersController } from "@/app/Http/Controllers/UsersController";
 import { UserService } from "@/app/Services/UserService";
@@ -23,6 +29,8 @@ export class AppServiceProvider extends ServiceProvider {
     public override boot(): void {
         const stack = this.app.make<MiddlewareStack>(MIDDLEWARE_STACK_KEY);
 
+        // Outermost: accumulate request lifecycle → emit one canonical line in finally
+        stack.add("wideEvent", wideEventMiddleware());
         stack.add(
             "csrf",
             verifyCsrf({
@@ -31,6 +39,6 @@ export class AppServiceProvider extends ServiceProvider {
                 tokenFieldName: csrfConfig.tokenField,
             }),
         );
-        stack.alias("web", ["csrf"]);
+        stack.alias("web", ["wideEvent", "csrf"]);
     }
 }

--- a/tests/Feature/WideEventSmoke.test.ts
+++ b/tests/Feature/WideEventSmoke.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Feature smoke: instrumented web request → exactly one Wide Event JSON line.
+ *
+ * @packageDocumentation
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
+
+const MINIMAL_FIELDS = [
+    "request_id",
+    "timestamp",
+    "method",
+    "path",
+    "status_code",
+    "duration_ms",
+    "outcome",
+] as const;
+
+function parseCanonicalLine(writeSpy: ReturnType<typeof spyOn>, index: number): Record<string, unknown> {
+    const args = writeSpy.mock.calls[index] as unknown[];
+    const payload = args[1];
+    if (typeof payload !== "string") {
+        throw new Error(`Expected Bun.write string payload at call ${index}`);
+    }
+    return JSON.parse(payload) as Record<string, unknown>;
+}
+
+function isCanonicalWideEvent(line: Record<string, unknown>): boolean {
+    return MINIMAL_FIELDS.every((key) => key in line) && !("level" in line) && !("message" in line);
+}
+
+describe("Wide Event smoke", () => {
+    let writeSpy: ReturnType<typeof spyOn> | undefined;
+
+    afterEach(() => {
+        writeSpy?.mockRestore();
+        writeSpy = undefined;
+    });
+
+    test("GET / emits exactly one canonical JSON line", async () => {
+        writeSpy = spyOn(Bun, "write").mockImplementation(() => Promise.resolve(100));
+
+        const app = await bootstrap();
+        const server = Bun.serve({
+            ...createAppServeOptions(app),
+            port: 0,
+            hostname: "127.0.0.1",
+        });
+
+        try {
+            const response = await fetch(`http://127.0.0.1:${server.port}/`);
+            expect(response.status).toBe(200);
+
+            const spy = writeSpy;
+            const canonicalLines: Record<string, unknown>[] = [];
+            for (let index = 0; index < spy.mock.calls.length; index++) {
+                const line = parseCanonicalLine(spy, index);
+                if (isCanonicalWideEvent(line)) {
+                    canonicalLines.push(line);
+                }
+            }
+
+            expect(canonicalLines).toHaveLength(1);
+
+            const line = canonicalLines[0];
+            expect(line).toBeDefined();
+            if (!line) {
+                throw new Error("Expected canonical wide event line");
+            }
+
+            expect(typeof line.request_id).toBe("string");
+            expect(typeof line.timestamp).toBe("string");
+            expect(line.method).toBe("GET");
+            expect(line.path).toBe("/");
+            expect(line.status_code).toBe(200);
+            expect(typeof line.duration_ms).toBe("number");
+            expect(line.outcome).toBe("success");
+        } finally {
+            server.stop();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Register `wideEventMiddleware` outermost on the `web` alias (`wideEvent` → `csrf`)
- Feature smoke: `GET /` → **exactly one** flat JSON Wide Event via `Bun.write` spy

Closes #33

## Depends on
Framework PR https://github.com/nino-ts/framework/pull/59 — use `bun link @ninots/framework` for local QA

## Binding
- Consilium: workspace `docs/sprint-9/consilium.md`
- Refs: https://loggingsucks.com/ · https://bun.com/docs/llms.txt
- CLI entry remains `nino` → `bootstrap/cli.ts`

## Test plan
- [x] `bun test tests/Feature/WideEventSmoke.test.ts` — pass
- [x] `bun test` full suite — 23 pass
- [x] `bun run type-check` — exit 0
- [ ] Ivy QA sign-off
- [ ] Remy: merge **regular** only

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Wide Event instrumentation to web requests.
  * Web requests now produce structured event data, including request details, status, timing, and outcome.

* **Tests**
  * Added coverage to verify that canonical Wide Event records are emitted with the expected fields and values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->