### PR TITLE
fix: same-repo CI gate + Bun-only + Biome 2.5.4 (Fixes #40)

### DIFF
--- a/.commitlintrc.mjs
+++ b/.commitlintrc.mjs
@@ -1,0 +1,35 @@
+export default {
+    rules: {
+        "body-leading-blank": [1, "always"],
+        "body-max-line-length": [1, "always", 100],
+        "footer-leading-blank": [1, "always"],
+        "footer-max-line-length": [1, "always", 100],
+        "header-max-length": [1, "always", 100],
+        "subject-case": [
+            1,
+            "never",
+            ["sentence-case", "start-case", "pascal-case", "upper-case"],
+        ],
+        "subject-empty": [1, "never"],
+        "subject-full-stop": [1, "never", "."],
+        "type-case": [1, "always", "lower-case"],
+        "type-empty": [1, "never"],
+        "type-enum": [
+            1,
+            "always",
+            [
+                "build",
+                "chore",
+                "ci",
+                "docs",
+                "feat",
+                "fix",
+                "perf",
+                "refactor",
+                "revert",
+                "style",
+                "test",
+            ],
+        ],
+    },
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Link workspace @ninots/* for type-check
+        run: bun run deps:link
+
       - name: Type-check
         run: bun run type-check
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ This starter is **TypeScript + Bun**: sources stay `.ts` / `.tsx` executed by Bu
 ## Quickstart (local Bun)
 
 ```bash
-# 1) Resolve @ninots/view (file dep via .deps/) + install
+# 1) Resolve @ninots/view (file dep via .deps/) + install + link workspace packages for tsc
 bun run deps:fetch
 bun install
+bun run deps:link
 
 # 2) Copy env
 cp .env.example .env
@@ -76,7 +77,8 @@ Entry command: `./nino serve --port 3000` (wrapper → `bootstrap/cli.ts`).
 
 | Command | Description |
 | --- | --- |
-| `bun run deps:fetch` | Ensure `.deps/ninots-framework` (hub link or git clone) |
+| `bun run deps:fetch` | Ensure `.deps/ninots-framework` (hub copy or git clone) |
+| `bun run deps:link` | Symlink workspace `@ninots/*` into `node_modules` for `tsc` |
 | `bun run dev` | `nino serve` with hot reload |
 | `bun run start` | Production-style serve |
 | `bun run build` | Compiled binary (`ninots`) |

--- a/README.md
+++ b/README.md
@@ -13,8 +13,15 @@ Nino focuses on developer experience inspired by Laravel and Next.js, while rema
 
 ## Requirements
 
-- [Bun](https://bun.sh/) (latest stable recommended)
-- Optional: [Docker Desktop](https://www.docker.com/products/docker-desktop/) for `docker compose up`
+**Official support: Bun only.**
+
+| Supported | Unsupported |
+| --- | --- |
+| [Bun](https://bun.sh/) (runtime + package manager) | npm client, Node.js, yarn, pnpm |
+
+This starter is **TypeScript + Bun**: sources stay `.ts` / `.tsx` executed by Bun. Type-check uses `tsc --noEmit` — there is no “emit JS then run” DX, and we do not add app `.js` sources for that purpose.
+
+- Optional: [Docker Desktop](https://www.docker.com/products/docker-desktop/) for `docker compose up` (image still runs Bun)
 
 ## Quickstart (local Bun)
 
@@ -136,6 +143,18 @@ bun run lint
 ## Contributing
 
 Issues and pull requests are welcome in the [nino-ts organization](https://github.com/nino-ts).
+
+### Same-repo PRs (CI gate)
+
+Open pull requests **from a branch on `nino-ts/ninots`**, not from a personal fork.
+
+```bash
+git remote add upstream https://github.com/nino-ts/ninots.git   # if needed
+git push -u upstream HEAD:patch/your-branch
+# then open the PR head = nino-ts/ninots:patch/your-branch → base main
+```
+
+Cross-fork PRs may not receive GitHub Actions check-runs (see [#40](https://github.com/nino-ts/ninots/issues/40)). Use **regular merge** only (never squash or rebase).
 
 ## License
 

--- a/biome.json
+++ b/biome.json
@@ -29,7 +29,10 @@
     "assist": {
         "enabled": true,
         "actions": {
-            "preset": "recommended"
+            "preset": "recommended",
+            "source": {
+                "organizeImports": "off"
+            }
         }
     },
     "linter": {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
     "root": true,
     "vcs": {
         "enabled": true,
@@ -29,13 +29,13 @@
     "assist": {
         "enabled": true,
         "actions": {
-            "recommended": true
+            "preset": "recommended"
         }
     },
     "linter": {
         "enabled": true,
         "rules": {
-            "recommended": true,
+            "preset": "recommended",
             "complexity": {
                 "noForEach": "error",
                 "useArrowFunction": "error",

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,8 @@
             "!**/dist",
             "!**/build",
             "!**/docs",
-            "!**/.deps"
+            "!**/.deps",
+            "!**/types/routes.d.ts"
         ]
     },
     "formatter": {

--- a/bun.lock
+++ b/bun.lock
@@ -9,30 +9,30 @@
         "@ninots/view": "file:.deps/ninots-framework/packages/view",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.14",
+        "@biomejs/biome": "2.5.4",
         "@types/bun": "^1.3.13",
         "typescript": "^6.0.3",
       },
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.4.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.14", "@biomejs/cli-darwin-x64": "2.4.14", "@biomejs/cli-linux-arm64": "2.4.14", "@biomejs/cli-linux-arm64-musl": "2.4.14", "@biomejs/cli-linux-x64": "2.4.14", "@biomejs/cli-linux-x64-musl": "2.4.14", "@biomejs/cli-win32-arm64": "2.4.14", "@biomejs/cli-win32-x64": "2.4.14" }, "bin": { "biome": "bin/biome" } }, "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.14", "", { "os": "win32", "cpu": "x64" }, "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
     "@ninots/framework": ["@ninots/framework@0.10.1", "", { "peerDependencies": { "typescript": "catalog:" }, "bin": { "nino": "nino" } }, "sha512-XXY+2vDBqIRjCwHExejhoH9/S5wBQ0suQX53E/huA9VRrtEUSMv5C4cP3DMT0ftnF+oRAJKs3x1deC0U9PKSmg=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     },
     "scripts": {
         "deps:fetch": "bun run scripts/ensure-framework-deps.ts",
+        "deps:link": "bun run scripts/link-framework-workspace.ts",
         "dev": "bun --hot ./nino serve",
         "start": "bun ./nino serve --prod",
         "build": "bun build --compile --bytecode ./nino --outfile ninots",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
     "version": "0.4.0",
     "private": true,
     "type": "module",
+    "packageManager": "bun@1.3.14",
+    "engines": {
+        "bun": ">=1.3.0"
+    },
     "bin": {
         "nino": "./nino"
     },
@@ -26,7 +30,7 @@
         "@ninots/view": "file:.deps/ninots-framework/packages/view"
     },
     "devDependencies": {
-        "@biomejs/biome": "2.4.14",
+        "@biomejs/biome": "2.5.4",
         "@types/bun": "^1.3.13",
         "typescript": "^6.0.3"
     }

--- a/resources/views/welcome.tsx
+++ b/resources/views/welcome.tsx
@@ -14,8 +14,8 @@ function WelcomePage({
         <section className="welcome">
             <h1>Welcome to Ninots</h1>
             <p>
-                {subtitle} Explore <strong>api</strong>, <strong>web</strong>, and <strong>websocket</strong> surfaces. Try the{" "}
-                <a href={contactHref}>contact form</a>.
+                {subtitle} Explore <strong>api</strong>, <strong>web</strong>, and <strong>websocket</strong> surfaces.
+                Try the <a href={contactHref}>contact form</a>.
             </p>
         </section>
     );

--- a/routes/web.ts
+++ b/routes/web.ts
@@ -1,10 +1,4 @@
-import {
-    generateCsrfToken,
-    resolveCsrfConfig,
-    resolveSessionId,
-    route,
-    withSessionCookie,
-} from "@ninots/framework";
+import { generateCsrfToken, resolveCsrfConfig, resolveSessionId, route, withSessionCookie } from "@ninots/framework";
 import { render } from "@ninots/view";
 import type { Router } from "@ninots/framework";
 import { Welcome } from "@/resources/views/welcome";

--- a/scripts/ensure-framework-deps.ts
+++ b/scripts/ensure-framework-deps.ts
@@ -1,10 +1,12 @@
 /**
- * Ensures `.deps/ninots-framework` exists so `file:.deps/.../packages/view`
- * resolves. Prefers the hub sibling `../framework`; otherwise clones the
- * tagged release from GitHub (`@ninots/view` is not published on npm yet).
+ * Ensures `.deps/ninots-framework` is a full framework tree so:
+ * - `file:.deps/.../packages/view` resolves (`@ninots/view` is not on npm yet)
+ * - `deps:link` can expose workspace `@ninots/*` packages for `tsc` (published
+ *   `@ninots/framework` ships a bundled runtime but `.d.ts` re-exports packages
+ *   that are not published separately on npm)
  *
- * Also rewrites `catalog:` ranges in the view package.json so `bun install`
- * works outside the framework workspace.
+ * Prefers the hub sibling `../framework`; otherwise clones the tagged release.
+ * Rewrites `catalog:` ranges so `bun install` works outside the workspace.
  */
 
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -16,8 +18,11 @@ const DEPS_DIR = resolve(import.meta.dir, "..", ".deps");
 const FRAMEWORK_DIR = join(DEPS_DIR, "ninots-framework");
 const VIEW_DIR = join(FRAMEWORK_DIR, "packages", "view");
 const VIEW_MARKER = join(VIEW_DIR, "package.json");
+const ORM_MARKER = join(FRAMEWORK_DIR, "packages", "orm", "package.json");
+const FRAMEWORK_PKG = join(FRAMEWORK_DIR, "package.json");
 const HUB_FRAMEWORK = resolve(import.meta.dir, "..", "..", "framework");
-const PATCH_MARKER = join(VIEW_DIR, ".ninots-deps-patched");
+const VIEW_PATCH_MARKER = join(VIEW_DIR, ".ninots-deps-patched");
+const ROOT_PATCH_MARKER = join(FRAMEWORK_DIR, ".ninots-root-deps-patched");
 
 type JsonRecord = Record<string, unknown>;
 
@@ -37,20 +42,24 @@ function rewriteCatalog(deps: JsonRecord | undefined): void {
             deps[name] = "latest";
         } else if (name === "typescript") {
             deps[name] = "^6.0.0";
+        } else if (name === "@biomejs/biome") {
+            deps[name] = "2.5.4";
+        } else if (name === "typedoc") {
+            deps[name] = "^0.28.19";
         } else {
             deps[name] = "*";
         }
     }
 }
 
-function patchViewPackageJson(): void {
-    if (existsSync(PATCH_MARKER)) {
+function patchPackageJsonCatalogs(pkgPath: string, markerPath: string): void {
+    if (existsSync(markerPath)) {
         return;
     }
-    const raw = readFileSync(VIEW_MARKER, "utf8");
+    const raw = readFileSync(pkgPath, "utf8");
     const pkg: unknown = JSON.parse(raw);
     if (!isRecord(pkg)) {
-        throw new Error("view package.json is not an object");
+        throw new Error(`${pkgPath} is not an object`);
     }
     if (isRecord(pkg.devDependencies)) {
         rewriteCatalog(pkg.devDependencies);
@@ -58,47 +67,62 @@ function patchViewPackageJson(): void {
     if (isRecord(pkg.peerDependencies)) {
         rewriteCatalog(pkg.peerDependencies);
     }
-    writeFileSync(VIEW_MARKER, `${JSON.stringify(pkg, null, 4)}\n`);
-    writeFileSync(PATCH_MARKER, `${FRAMEWORK_REF}\n`);
+    if (isRecord(pkg.dependencies)) {
+        rewriteCatalog(pkg.dependencies);
+    }
+    writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 4)}\n`);
+    writeFileSync(markerPath, `${FRAMEWORK_REF}\n`);
 }
 
 function log(message: string): void {
     process.stdout.write(`${message}\n`);
 }
 
+function isCompleteFrameworkTree(): boolean {
+    return existsSync(FRAMEWORK_PKG) && existsSync(VIEW_MARKER) && existsSync(ORM_MARKER);
+}
+
+function shouldSkipCopy(src: string): boolean {
+    const normalized = src.replaceAll("\\", "/");
+    return (
+        normalized.includes("/node_modules/") ||
+        normalized.endsWith("/node_modules") ||
+        normalized.includes("/.git/") ||
+        normalized.endsWith("/.git")
+    );
+}
+
 async function materializeFramework(): Promise<void> {
-    if (existsSync(VIEW_MARKER)) {
+    if (isCompleteFrameworkTree()) {
         return;
     }
 
     mkdirSync(DEPS_DIR, { recursive: true });
+    if (existsSync(FRAMEWORK_DIR)) {
+        rmSync(FRAMEWORK_DIR, { recursive: true, force: true });
+    }
 
     if (existsSync(join(HUB_FRAMEWORK, "packages", "view", "package.json"))) {
         log(`copying hub framework → ${FRAMEWORK_DIR}`);
-        if (existsSync(FRAMEWORK_DIR)) {
-            rmSync(FRAMEWORK_DIR, { recursive: true, force: true });
-        }
-        // Copy only what we need so we can patch view/package.json without
-        // mutating the live hub tree.
-        mkdirSync(join(FRAMEWORK_DIR, "packages"), { recursive: true });
-        cpSync(join(HUB_FRAMEWORK, "packages", "view"), VIEW_DIR, { recursive: true });
+        cpSync(HUB_FRAMEWORK, FRAMEWORK_DIR, {
+            recursive: true,
+            filter: (src) => !shouldSkipCopy(src),
+        });
         return;
     }
 
     log(`cloning nino-ts/framework@${FRAMEWORK_REF} → ${FRAMEWORK_DIR}`);
-    if (existsSync(FRAMEWORK_DIR)) {
-        rmSync(FRAMEWORK_DIR, { recursive: true, force: true });
-    }
     await $`git clone --depth 1 --branch ${FRAMEWORK_REF} https://github.com/nino-ts/framework.git ${FRAMEWORK_DIR}`;
 }
 
 async function main(): Promise<void> {
     await materializeFramework();
-    if (!existsSync(VIEW_MARKER)) {
-        throw new Error(`missing ${VIEW_MARKER}`);
+    if (!isCompleteFrameworkTree()) {
+        throw new Error(`incomplete framework tree under ${FRAMEWORK_DIR}`);
     }
-    patchViewPackageJson();
-    log(`framework deps ok: ${VIEW_DIR}`);
+    patchPackageJsonCatalogs(VIEW_MARKER, VIEW_PATCH_MARKER);
+    patchPackageJsonCatalogs(FRAMEWORK_PKG, ROOT_PATCH_MARKER);
+    log(`framework deps ok: ${FRAMEWORK_DIR}`);
 }
 
 await main();

--- a/scripts/link-framework-workspace.ts
+++ b/scripts/link-framework-workspace.ts
@@ -1,0 +1,58 @@
+/**
+ * Symlinks workspace `@ninots/*` packages from `.deps/ninots-framework/packages`
+ * into `node_modules/@ninots/` so TypeScript can resolve re-exports from the
+ * published `@ninots/framework` meta-package `.d.ts` (those packages are not on npm).
+ *
+ * Run after `bun run deps:fetch` and `bun install`.
+ */
+
+import { existsSync, lstatSync, mkdirSync, readdirSync, rmSync, symlinkSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const STARTER_ROOT = resolve(import.meta.dir, "..");
+const FRAMEWORK_DIR = join(STARTER_ROOT, ".deps", "ninots-framework");
+const PACKAGES_DIR = join(FRAMEWORK_DIR, "packages");
+const SCOPE_DIR = join(STARTER_ROOT, "node_modules", "@ninots");
+
+function log(message: string): void {
+    process.stdout.write(`${message}\n`);
+}
+
+function linkPackage(name: string, target: string): void {
+    const dest = join(SCOPE_DIR, name);
+    if (existsSync(dest)) {
+        const stat = lstatSync(dest);
+        if (stat.isSymbolicLink() || stat.isDirectory()) {
+            rmSync(dest, { recursive: true, force: true });
+        }
+    }
+    symlinkSync(target, dest, "junction");
+    log(`linked @ninots/${name} → ${target}`);
+}
+
+function main(): void {
+    if (!existsSync(join(PACKAGES_DIR, "orm", "package.json"))) {
+        throw new Error(`missing framework packages under ${PACKAGES_DIR}; run bun run deps:fetch first`);
+    }
+    if (!existsSync(join(STARTER_ROOT, "node_modules"))) {
+        throw new Error("node_modules missing; run bun install first");
+    }
+
+    mkdirSync(SCOPE_DIR, { recursive: true });
+
+    for (const name of readdirSync(PACKAGES_DIR)) {
+        const pkgDir = join(PACKAGES_DIR, name);
+        if (!existsSync(join(pkgDir, "package.json"))) {
+            continue;
+        }
+        // Keep the file: view install from package.json; only fill gaps for types.
+        if (name === "view" && existsSync(join(SCOPE_DIR, "view"))) {
+            continue;
+        }
+        linkPackage(name, pkgDir);
+    }
+
+    log("workspace @ninots/* packages linked for tsc");
+}
+
+main();

--- a/tests/Feature/MakeGenerator.test.ts
+++ b/tests/Feature/MakeGenerator.test.ts
@@ -3,12 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { existsSync } from "node:fs";
-import {
-    Kernel,
-    MakeControllerCommand,
-    Router,
-    ROUTER_KEY,
-} from "@ninots/framework";
+import { Kernel, MakeControllerCommand, type Router, ROUTER_KEY } from "@ninots/framework";
 import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
 
 const SESSION_COOKIE = "ninots_session";

--- a/tests/Feature/MakeModule.test.ts
+++ b/tests/Feature/MakeModule.test.ts
@@ -65,9 +65,7 @@ describe("nino make:module", () => {
         const exitCode = await kernel.run(["make:module", "Billing"]);
 
         expect(exitCode).toBe(0);
-        expect(existsSync(join(root, "app/Modules/Billing/Providers/BillingServiceProvider.ts"))).toBe(
-            true,
-        );
+        expect(existsSync(join(root, "app/Modules/Billing/Providers/BillingServiceProvider.ts"))).toBe(true);
         expect(existsSync(join(root, "app/Modules/Billing/routes.ts"))).toBe(true);
         expect(existsSync(join(root, "src"))).toBe(false);
 
@@ -83,9 +81,7 @@ describe("nino make:module", () => {
         const exitCode = await kernel.run(["make:module", "Catalog", "--all"]);
 
         expect(exitCode).toBe(0);
-        expect(
-            existsSync(join(root, "app/Modules/Catalog/Http/Controllers/CatalogController.ts")),
-        ).toBe(true);
+        expect(existsSync(join(root, "app/Modules/Catalog/Http/Controllers/CatalogController.ts"))).toBe(true);
         expect(existsSync(join(root, "app/Modules/Catalog/Models/Catalog.ts"))).toBe(true);
         expect(existsSync(join(root, "src"))).toBe(false);
 

--- a/tests/Feature/MigrateLifecycle.test.ts
+++ b/tests/Feature/MigrateLifecycle.test.ts
@@ -1,12 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "node:path";
-import {
-    Kernel,
-    MigrateCommand,
-    MigrateRefreshCommand,
-    MigrateRollbackCommand,
-    Migrator,
-} from "@ninots/framework";
+import { Kernel, MigrateCommand, MigrateRefreshCommand, MigrateRollbackCommand, Migrator } from "@ninots/framework";
 import databaseConfig from "@/config/database";
 import { setupTestDatabase, teardownTestDatabase } from "@/tests/support/database";
 
@@ -78,9 +72,9 @@ describe("migrate lifecycle (rollback + refresh)", () => {
 
     test("migrate:refresh restores a clean post-migrate schema", async () => {
         const database = await setupTestDatabase();
-        await database.connection().run(
-            "INSERT INTO users (email, name, password) VALUES ('stale@ninots.test', 'Stale', 'secret')",
-        );
+        await database
+            .connection()
+            .run("INSERT INTO users (email, name, password) VALUES ('stale@ninots.test', 'Stale', 'secret')");
 
         const migrator = new Migrator({
             database,

--- a/tests/Feature/UserFactory.test.ts
+++ b/tests/Feature/UserFactory.test.ts
@@ -27,9 +27,7 @@ describe("UserFactory", () => {
     });
 
     test("state() overrides attributes without hardcoded fixtures", async () => {
-        const user = await User.factory()
-            .state({ name: "Seeded Nova" })
-            .create();
+        const user = await User.factory().state({ name: "Seeded Nova" }).create();
 
         expect(user.name).toBe("Seeded Nova");
     });

--- a/tests/Feature/WideEventSmoke.test.ts
+++ b/tests/Feature/WideEventSmoke.test.ts
@@ -7,15 +7,7 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
 
-const MINIMAL_FIELDS = [
-    "request_id",
-    "timestamp",
-    "method",
-    "path",
-    "status_code",
-    "duration_ms",
-    "outcome",
-] as const;
+const MINIMAL_FIELDS = ["request_id", "timestamp", "method", "path", "status_code", "duration_ms", "outcome"] as const;
 
 function parseCanonicalLine(writeSpy: ReturnType<typeof spyOn>, index: number): Record<string, unknown> {
     const args = writeSpy.mock.calls[index] as unknown[];

--- a/tests/Types/expect.ts
+++ b/tests/Types/expect.ts
@@ -4,8 +4,6 @@
  * @packageDocumentation
  */
 
-export type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
-    ? true
-    : false;
+export type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
 export type Expect<T extends true> = T;

--- a/tests/Types/route-types.positive.ts
+++ b/tests/Types/route-types.positive.ts
@@ -10,9 +10,7 @@ import type { Equal, Expect } from "./expect";
 type _home = Expect<Equal<RouteRegistry["home"], Record<never, never>>>;
 type _show = Expect<Equal<RouteRegistry["users.show"], { id: string }>>;
 
-type HasRequiredParams<Name extends keyof RouteRegistry> = [keyof RouteRegistry[Name]] extends [never]
-    ? false
-    : true;
+type HasRequiredParams<Name extends keyof RouteRegistry> = [keyof RouteRegistry[Name]] extends [never] ? false : true;
 
 type _homeOptional = Expect<Equal<HasRequiredParams<"home">, false>>;
 type _showRequired = Expect<Equal<HasRequiredParams<"users.show">, true>>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,7 @@
         "noUncheckedIndexedAccess": true,
         "noImplicitOverride": true,
         "paths": {
-            "@/*": ["./*"],
-            "@ninots/routing": ["./node_modules/@ninots/framework/node_modules/@ninots/routing/index.ts"]
+            "@/*": ["./*"]
         },
         // Some stricter flags (disabled by default)
         "noUnusedLocals": false,

--- a/types/routes.d.ts
+++ b/types/routes.d.ts
@@ -3,7 +3,7 @@ declare module "@ninots/routing" {
     interface RouteRegistry {
         "contact.create": Record<never, never>;
         "contact.store": Record<never, never>;
-        home: Record<never, never>;
+        "home": Record<never, never>;
         "users.destroy": { id: string };
         "users.index": Record<never, never>;
         "users.show": { id: string };

--- a/types/routes.d.ts
+++ b/types/routes.d.ts
@@ -3,7 +3,7 @@ declare module "@ninots/routing" {
     interface RouteRegistry {
         "contact.create": Record<never, never>;
         "contact.store": Record<never, never>;
-        "home": Record<never, never>;
+        home: Record<never, never>;
         "users.destroy": { id: string };
         "users.index": Record<never, never>;
         "users.show": { id: string };


### PR DESCRIPTION
## Summary
- Document **same-repo PRs** in README so GitHub Actions (CI + commitlint) run on contribution PRs — closes the process gap from fork PR #39 (`Fixes #40`).
- Declare official support as **Bun only** (unsupported: npm client, Node.js, yarn, pnpm); TypeScript+Bun with `noEmit` DX; `engines` / `packageManager` in `package.json`.
- Bump `@biomejs/biome` to **2.5.4** and run `bunx biome migrate --write`.

## Test plan
- [ ] CI workflow green on this same-repo PR
- [ ] Lint commits (commitlint) green
- [ ] `bun test` (32) local PASS
- [ ] Merge with **regular merge** only (never squash/rebase)
- [ ] Confirm #40 closes; leave #38 open


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Bun is the officially supported runtime and package manager.
  * Added supported and unsupported runtime guidance, TypeScript usage details, and Docker Desktop notes.
  * Expanded contribution instructions for same-repository pull requests, including setup commands and merge requirements.

* **Chores**
  * Updated project tooling configuration and documented the required Bun version.
  * Refreshed linting configuration to align with the latest supported setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->