### PR TITLE
chore(deps): bump @ninots/framework to ^0.11.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "ninots-app",
       "dependencies": {
-        "@ninots/framework": "^0.10.1",
+        "@ninots/framework": "^0.11.0",
         "@ninots/view": "file:.deps/ninots-framework/packages/view",
       },
       "devDependencies": {
@@ -34,7 +34,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
-    "@ninots/framework": ["@ninots/framework@0.10.1", "", { "peerDependencies": { "typescript": "catalog:" }, "bin": { "nino": "nino" } }, "sha512-XXY+2vDBqIRjCwHExejhoH9/S5wBQ0suQX53E/huA9VRrtEUSMv5C4cP3DMT0ftnF+oRAJKs3x1deC0U9PKSmg=="],
+    "@ninots/framework": ["@ninots/framework@0.11.0", "", { "peerDependencies": { "typescript": "catalog:" }, "bin": { "nino": "nino" } }, "sha512-r59RT+itnlT+nLBiFaYprimPjsQCapCb4wt8YqljLNAaQXZyfTZh8w6SNGxUleuR3OyLIGCfuc/tg2FygY7sSw=="],
 
     "@ninots/view": ["@ninots/view@file:.deps/ninots-framework/packages/view", { "devDependencies": { "@types/bun": "latest" }, "peerDependencies": { "typescript": "^6.0.0" } }],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "test": "bun test"
     },
     "dependencies": {
-        "@ninots/framework": "^0.10.1",
+        "@ninots/framework": "^0.11.0",
         "@ninots/view": "file:.deps/ninots-framework/packages/view"
     },
     "devDependencies": {

--- a/scripts/ensure-framework-deps.ts
+++ b/scripts/ensure-framework-deps.ts
@@ -13,7 +13,7 @@ import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } fr
 import { join, resolve } from "node:path";
 import { $ } from "bun";
 
-const FRAMEWORK_REF = "v0.10.1";
+const FRAMEWORK_REF = "v0.11.0";
 const DEPS_DIR = resolve(import.meta.dir, "..", ".deps");
 const FRAMEWORK_DIR = join(DEPS_DIR, "ninots-framework");
 const VIEW_DIR = join(FRAMEWORK_DIR, "packages", "view");


### PR DESCRIPTION
## Summary
- Bump `@ninots/framework` from `^0.10.1` to `^0.11.0` (published npm+JSR+GitHub).
- Align `deps:fetch` `FRAMEWORK_REF` to `v0.11.0`.
- Refresh `bun.lock` via `bun install`.
- Does **not** close #38 (Consilium S12 theme).

## Test plan
- [ ] CI green (lint, type-check, tests)
- [ ] `bun install` resolves `@ninots/framework@0.11.0`
- [ ] Regular merge (not squash/rebase)