### PR TITLE
feat(cli): auto-hook routes:compile on serve in development (Fixes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,12 @@ Hub developers (local `framework/` sibling) can optionally override with `bun li
 
 ### Typed routes
 
+In development (`bun run dev` / `nino serve` with `APP_DEBUG=true`), Ninots watches `routes/` and `app/Modules/` and rebuilds `types/routes.d.ts` automatically (debounce + same emitter as `routes:compile`).
+
+For CI and production builds, keep the explicit compile:
+
 ```bash
-bun run nino routes:compile   # writes types/routes.d.ts
+bun run nino routes:compile   # writes types/routes.d.ts (CI / manual)
 bun run verify:route-types    # fail-fixture checks
 ```
 
@@ -79,7 +83,7 @@ Entry command: `./nino serve --port 3000` (wrapper → `bootstrap/cli.ts`).
 | --- | --- |
 | `bun run deps:fetch` | Ensure `.deps/ninots-framework` (hub copy or git clone) |
 | `bun run deps:link` | Symlink workspace `@ninots/*` into `node_modules` for `tsc` |
-| `bun run dev` | `nino serve` with hot reload |
+| `bun run dev` | `nino serve` with hot reload; auto-rebuilds `types/routes.d.ts` in development |
 | `bun run start` | Production-style serve |
 | `bun run build` | Compiled binary (`ninots`) |
 | `bun run nino --help` | CLI help |
@@ -99,10 +103,11 @@ Entry command: `./nino serve --port 3000` (wrapper → `bootstrap/cli.ts`).
 3. Registers providers from `bootstrap/providers.ts`
 4. Boots the app
 5. Starts `Bun.serve(...)` with generated options
+6. In development, starts `startRoutesAutoHook` (watch → debounce → `types/routes.d.ts`)
 
 ### Routing
 
-Fluent registration under `routes/web.ts` and `routes/api.ts` (Laravel-like). File-based `loadRoutes` exists in `@ninots/routing` but is **not** wired in this starter.
+Fluent registration under `routes/web.ts` and `routes/api.ts` (Laravel-like). File-based `loadRoutes` exists in `@ninots/routing` but is **not** wired in this starter. Dev auto-hook rebuilds `types/routes.d.ts` when those files change; CI still runs `nino routes:compile` explicitly.
 
 ### Layout
 

--- a/bootstrap/cli.ts
+++ b/bootstrap/cli.ts
@@ -96,10 +96,10 @@ class ServeCommand extends Command {
                 routesDirs: ["routes", "app/Modules"],
                 resolveRouter: () => app.make<Router>(ROUTER_KEY),
                 signal: abortController.signal,
-                onWarn: (message) => {
+                onWarn: (message: string) => {
                     this.warn(message);
                 },
-                onWritten: (outRel) => {
+                onWritten: (outRel: string) => {
                     this.info(`✓ ${outRel} updated`);
                 },
             }).catch((error: unknown) => {

--- a/bootstrap/cli.ts
+++ b/bootstrap/cli.ts
@@ -16,6 +16,7 @@ import {
     ROUTER_KEY,
     RoutesCompileCommand,
     SeederRunner,
+    startRoutesAutoHook,
 } from "@ninots/framework";
 import type { Router } from "@ninots/framework";
 import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
@@ -85,12 +86,31 @@ class ServeCommand extends Command {
         const serveOptions = createAppServeOptions(app);
         serveOptions.port = port;
 
+        const abortController = new AbortController();
         const server = Bun.serve(serveOptions);
         this.info(`Ninots server running at ${server.url}`);
         this.info("Press Ctrl+C to stop");
 
+        if (app.getConfig().development) {
+            startRoutesAutoHook({
+                routesDirs: ["routes", "app/Modules"],
+                resolveRouter: () => app.make<Router>(ROUTER_KEY),
+                signal: abortController.signal,
+                onWarn: (message) => {
+                    this.warn(message);
+                },
+                onWritten: (outRel) => {
+                    this.info(`✓ ${outRel} updated`);
+                },
+            }).catch((error: unknown) => {
+                const msg = error instanceof Error ? error.message : String(error);
+                this.warn(`routes auto-hook stopped: ${msg}`);
+            });
+        }
+
         await new Promise<void>((resolve) => {
             const stop = (): void => {
+                abortController.abort();
                 server.stop(true);
                 resolve();
             };

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "ninots-app",
       "dependencies": {
-        "@ninots/framework": "^0.11.0",
+        "@ninots/framework": "^0.12.0",
         "@ninots/view": "file:.deps/ninots-framework/packages/view",
       },
       "devDependencies": {
@@ -34,7 +34,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
-    "@ninots/framework": ["@ninots/framework@0.11.0", "", { "peerDependencies": { "typescript": "catalog:" }, "bin": { "nino": "nino" } }, "sha512-r59RT+itnlT+nLBiFaYprimPjsQCapCb4wt8YqljLNAaQXZyfTZh8w6SNGxUleuR3OyLIGCfuc/tg2FygY7sSw=="],
+    "@ninots/framework": ["@ninots/framework@0.12.0", "", { "peerDependencies": { "typescript": "catalog:" }, "bin": { "nino": "nino" } }, "sha512-tTZY8tLqpYLh2glL6d53VlLyuM2YnWVg6EAht3LmAShQnt9AVgcF6jGAzRow+TtAM3bqayIAh1EXUSJm+CI5eQ=="],
 
     "@ninots/view": ["@ninots/view@file:.deps/ninots-framework/packages/view", { "devDependencies": { "@types/bun": "latest" }, "peerDependencies": { "typescript": "^6.0.0" } }],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "test": "bun test"
     },
     "dependencies": {
-        "@ninots/framework": "^0.11.0",
+        "@ninots/framework": "^0.12.0",
         "@ninots/view": "file:.deps/ninots-framework/packages/view"
     },
     "devDependencies": {

--- a/scripts/ensure-framework-deps.ts
+++ b/scripts/ensure-framework-deps.ts
@@ -13,7 +13,7 @@ import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } fr
 import { join, resolve } from "node:path";
 import { $ } from "bun";
 
-const FRAMEWORK_REF = "v0.11.0";
+const FRAMEWORK_REF = "v0.12.0";
 const DEPS_DIR = resolve(import.meta.dir, "..", ".deps");
 const FRAMEWORK_DIR = join(DEPS_DIR, "ninots-framework");
 const VIEW_DIR = join(FRAMEWORK_DIR, "packages", "view");


### PR DESCRIPTION
## PR Description

Sprint 12 Phase A.2 + B — wire `startRoutesAutoHook` into `ServeCommand` after `Bun.serve()`, abort on SIGINT/SIGTERM, document auto-hook vs manual CI compile.

**Draft** until `@ninots/framework@0.12.0` is published (export `startRoutesAutoHook`). Then: undraft, bump `package.json` to `^0.12.0`, refresh lockfile.

## Changes Made

- [x] Feature added
- [x] Documentation updated
- [ ] Dependencies updated (pending `^0.12.0` after publish)

## Testing

- `bun test` — 32 pass (local, linked framework)
- `verify:route-types` — 4 fail-fixtures rejected as expected
- Smoke (QA): `bun run dev` → edit `routes/` → `types/routes.d.ts` updates

## Related Issues

Fixes #38

Depends on: https://github.com/nino-ts/framework/pull/74 → merge → **0.12.0** publish.

## Additional Notes

- Merge: **regular merge only**
- Commit: `efc7f14`
- Do not close #38 until this lands with `Fixes #38` on main

Made with [Cursor](https://cursor.com)