### PR TITLE
fix(cli): isolate bootstrap in routes auto-hook (Fixes #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Entry command: `./nino serve --port 3000` (wrapper → `bootstrap/cli.ts`).
 3. Registers providers from `bootstrap/providers.ts`
 4. Boots the app
 5. Starts `Bun.serve(...)` with generated options
-6. In development, starts `startRoutesAutoHook` (watch → debounce → `types/routes.d.ts`)
+6. In development, starts `startRoutesAutoHook` (watch → debounce → isolated `bootstrap()` → `types/routes.d.ts`)
 
 ### Routing
 

--- a/bootstrap/cli.ts
+++ b/bootstrap/cli.ts
@@ -13,14 +13,13 @@ import {
     MigrateRefreshCommand,
     MigrateRollbackCommand,
     Migrator,
-    ROUTER_KEY,
     RoutesCompileCommand,
     SeederRunner,
     startRoutesAutoHook,
 } from "@ninots/framework";
-import type { Router } from "@ninots/framework";
 import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
 import { getDatabaseManager } from "@/bootstrap/database";
+import { resolveFreshRouter } from "@/bootstrap/resolveFreshRouter";
 import databaseConfig from "@/config/database";
 import { DatabaseSeeder } from "@/database/seeders/DatabaseSeeder";
 import packageJson from "../package.json";
@@ -94,7 +93,8 @@ class ServeCommand extends Command {
         if (app.getConfig().development) {
             startRoutesAutoHook({
                 routesDirs: ["routes", "app/Modules"],
-                resolveRouter: () => app.make<Router>(ROUTER_KEY),
+                // Isolated bootstrap — never the long-lived serve app (Fixes #45 / Consilium Desacordo 4).
+                resolveRouter: resolveFreshRouter,
                 signal: abortController.signal,
                 onWarn: (message: string) => {
                     this.warn(message);
@@ -127,8 +127,7 @@ class RoutesCommand extends Command {
     protected override description = "List all registered routes";
 
     public async handle(): Promise<number> {
-        const app = await bootstrap();
-        const router = app.make<Router>(ROUTER_KEY);
+        const router = await resolveFreshRouter();
 
         this.info("Registered routes:");
         this.line("");
@@ -167,10 +166,7 @@ kernel.register(new RoutesCommand());
 kernel.register(new CacheClearCommand());
 kernel.register(
     new RoutesCompileCommand({
-        async resolveRouter() {
-            const app = await bootstrap();
-            return app.make<Router>(ROUTER_KEY);
-        },
+        resolveRouter: resolveFreshRouter,
     }),
 );
 kernel.register(

--- a/bootstrap/resolveFreshRouter.ts
+++ b/bootstrap/resolveFreshRouter.ts
@@ -1,0 +1,14 @@
+import { ROUTER_KEY } from "@ninots/framework";
+import type { Router } from "@ninots/framework";
+import { bootstrap } from "@/bootstrap/app";
+
+/**
+ * Boot a disposable Application and return its Router.
+ *
+ * Used by `routes:compile` and the serve auto-hook so registry emit never
+ * reads the long-lived serve app's in-memory Router (stale after route edits).
+ */
+export async function resolveFreshRouter(): Promise<Router> {
+    const app = await bootstrap();
+    return app.make<Router>(ROUTER_KEY);
+}

--- a/tests/Feature/ResolveFreshRouter.test.ts
+++ b/tests/Feature/ResolveFreshRouter.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { ROUTER_KEY, Route } from "@ninots/framework";
+import type { Router } from "@ninots/framework";
+import { bootstrap } from "@/bootstrap/app";
+import { resolveFreshRouter } from "@/bootstrap/resolveFreshRouter";
+
+const starterRoot = join(import.meta.dir, "../..");
+
+function namedRouteNames(router: Router): string[] {
+    const names: string[] = [];
+    for (const route of router.getRoutes()) {
+        const name: string | undefined = route.getName();
+        if (name !== undefined) {
+            names.push(name);
+        }
+    }
+    return names.toSorted((left: string, right: string) => left.localeCompare(right));
+}
+
+describe("resolveFreshRouter (isolated bootstrap)", () => {
+    test("returns a distinct Router instance from a discarded bootstrap", async () => {
+        const first = await resolveFreshRouter();
+        const second = await resolveFreshRouter();
+
+        expect(first).not.toBe(second);
+        expect(namedRouteNames(first)).toEqual(namedRouteNames(second));
+        expect(namedRouteNames(first)).toContain("home");
+        expect(namedRouteNames(first)).toContain("users.show");
+        expect(first.getRoutes()[0]).toBeInstanceOf(Route);
+    });
+
+    test("closed-over serve app.make stays the same instance (stale pattern)", async () => {
+        const app = await bootstrap();
+        const closedOver = (): Router => app.make<Router>(ROUTER_KEY);
+
+        expect(closedOver()).toBe(closedOver());
+        expect(closedOver()).not.toBe(await resolveFreshRouter());
+    });
+
+    test("ServeCommand auto-hook wires resolveFreshRouter, not closed-over app.make", async () => {
+        const cli = await readFile(join(starterRoot, "bootstrap/cli.ts"), "utf8");
+        const callStart = cli.indexOf("startRoutesAutoHook({");
+        expect(callStart).toBeGreaterThan(-1);
+
+        const hookBlock = cli.slice(callStart, cli.indexOf("}).catch", callStart));
+
+        expect(hookBlock).toContain("resolveRouter: resolveFreshRouter");
+        expect(hookBlock).not.toMatch(/resolveRouter:\s*\(\)\s*=>\s*app\.make/);
+    });
+});


### PR DESCRIPTION
## Summary
- `ServeCommand` auto-hook now uses `resolveFreshRouter()` (disposable `bootstrap()` → `ROUTER_KEY`) instead of closing over the long-lived serve `app` Router — Consilium Desacordo 4 / same pattern as `RoutesCompileCommand`.
- Shared helper + regression tests; README notes isolated bootstrap on watch.
- Closes Sprint 12 QA blocker: new named routes land in `types/routes.d.ts` under `bun --hot` / `bun run dev`.

## Test plan
- [x] `bun test` (35 pass)
- [x] `bun run verify:route-types`
- [x] `bun run type-check`
- [x] Smoke: `bun --hot ./nino serve` → add named route `qa.smoke` → `types/routes.d.ts` gains `qa.smoke`
- [ ] CI green on this PR
- [ ] Ivy re-smoke SC#1 before Sprint 12 Done

Fixes #45