### PR TITLE
fix(cli): spawn routes:compile in serve auto-hook (Fixes #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Entry command: `./nino serve --port 3000` (wrapper → `bootstrap/cli.ts`).
 3. Registers providers from `bootstrap/providers.ts`
 4. Boots the app
 5. Starts `Bun.serve(...)` with generated options
-6. In development, starts `startRoutesAutoHook` (watch → debounce → isolated `bootstrap()` → `types/routes.d.ts`)
+6. In development, starts `startRoutesAutoHook` (watch → debounce → cold `nino routes:compile` subprocess → `types/routes.d.ts`)
 
 ### Routing
 

--- a/bootstrap/cli.ts
+++ b/bootstrap/cli.ts
@@ -91,10 +91,40 @@ class ServeCommand extends Command {
         this.info("Press Ctrl+C to stop");
 
         if (app.getConfig().development) {
+            const routesArtifactRel = "types/routes.d.ts";
+            const routesArtifactPath = path.join(process.cwd(), routesArtifactRel);
+
             startRoutesAutoHook({
                 routesDirs: ["routes", "app/Modules"],
-                // Isolated bootstrap — never the long-lived serve app (Fixes #45 / Consilium Desacordo 4).
+                // Isolated bootstrap kept for type + fallback; debounce uses cold subprocess
+                // so Bun module cache cannot stale the registry (Fixes #47).
                 resolveRouter: resolveFreshRouter,
+                compileArtifact: async (): Promise<"written" | "unchanged"> => {
+                    const artifact = Bun.file(routesArtifactPath);
+                    const before = (await artifact.exists()) ? await artifact.text() : "";
+
+                    const proc = Bun.spawn(["bun", "./nino", "routes:compile"], {
+                        cwd: process.cwd(),
+                        stdout: "pipe",
+                        stderr: "pipe",
+                    });
+                    const [exitCode, stdout, stderr] = await Promise.all([
+                        proc.exited,
+                        new Response(proc.stdout).text(),
+                        new Response(proc.stderr).text(),
+                    ]);
+                    if (exitCode !== 0) {
+                        const detail = stderr.trim().length > 0 ? stderr.trim() : stdout.trim();
+                        throw new Error(
+                            detail.length > 0
+                                ? `routes:compile exited ${exitCode}: ${detail}`
+                                : `routes:compile exited ${exitCode}`,
+                        );
+                    }
+
+                    const after = await Bun.file(routesArtifactPath).text();
+                    return before === after ? "unchanged" : "written";
+                },
                 signal: abortController.signal,
                 onWarn: (message: string) => {
                     this.warn(message);

--- a/bootstrap/resolveFreshRouter.ts
+++ b/bootstrap/resolveFreshRouter.ts
@@ -5,8 +5,10 @@ import { bootstrap } from "@/bootstrap/app";
 /**
  * Boot a disposable Application and return its Router.
  *
- * Used by `routes:compile` and the serve auto-hook so registry emit never
+ * Used by `routes:compile` and `routes:list` so registry emit / listing never
  * reads the long-lived serve app's in-memory Router (stale after route edits).
+ * Serve auto-hook debounce prefers a cold `routes:compile` subprocess (Fixes #47)
+ * while still passing this resolver for the hook option contract (Fixes #45).
  */
 export async function resolveFreshRouter(): Promise<Router> {
     const app = await bootstrap();

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "ninots-app",
       "dependencies": {
-        "@ninots/framework": "^0.12.0",
+        "@ninots/framework": "^0.12.1",
         "@ninots/view": "file:.deps/ninots-framework/packages/view",
       },
       "devDependencies": {
@@ -34,7 +34,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
-    "@ninots/framework": ["@ninots/framework@0.12.0", "", { "peerDependencies": { "typescript": "catalog:" }, "bin": { "nino": "nino" } }, "sha512-tTZY8tLqpYLh2glL6d53VlLyuM2YnWVg6EAht3LmAShQnt9AVgcF6jGAzRow+TtAM3bqayIAh1EXUSJm+CI5eQ=="],
+    "@ninots/framework": ["@ninots/framework@0.12.1", "", { "peerDependencies": { "typescript": "catalog:" }, "bin": { "nino": "nino" } }, "sha512-b6E7adKjajfCZKFgyt/jfoPrgFJR29GWNHs8arMmj5RR/nRNbDHiqCCyb8UxaliB7OeVCsAVeJMLgcSGp3Ubzg=="],
 
     "@ninots/view": ["@ninots/view@file:.deps/ninots-framework/packages/view", { "devDependencies": { "@types/bun": "latest" }, "peerDependencies": { "typescript": "^6.0.0" } }],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "test": "bun test"
     },
     "dependencies": {
-        "@ninots/framework": "^0.12.0",
+        "@ninots/framework": "^0.12.1",
         "@ninots/view": "file:.deps/ninots-framework/packages/view"
     },
     "devDependencies": {

--- a/tests/Feature/ResolveFreshRouter.test.ts
+++ b/tests/Feature/ResolveFreshRouter.test.ts
@@ -39,7 +39,7 @@ describe("resolveFreshRouter (isolated bootstrap)", () => {
         expect(closedOver()).not.toBe(await resolveFreshRouter());
     });
 
-    test("ServeCommand auto-hook wires resolveFreshRouter, not closed-over app.make", async () => {
+    test("ServeCommand auto-hook wires compileArtifact spawn + resolveFreshRouter", async () => {
         const cli = await readFile(join(starterRoot, "bootstrap/cli.ts"), "utf8");
         const callStart = cli.indexOf("startRoutesAutoHook({");
         expect(callStart).toBeGreaterThan(-1);
@@ -47,6 +47,8 @@ describe("resolveFreshRouter (isolated bootstrap)", () => {
         const hookBlock = cli.slice(callStart, cli.indexOf("}).catch", callStart));
 
         expect(hookBlock).toContain("resolveRouter: resolveFreshRouter");
+        expect(hookBlock).toContain("compileArtifact:");
+        expect(hookBlock).toContain('Bun.spawn(["bun", "./nino", "routes:compile"]');
         expect(hookBlock).not.toMatch(/resolveRouter:\s*\(\)\s*=>\s*app\.make/);
     });
 });


### PR DESCRIPTION
## Summary
- Serve auto-hook debounce now runs `Bun.spawn([\"bun\", \"./nino\", \"routes:compile\"])` via `compileArtifact`, comparing `types/routes.d.ts` before/after.
- Keeps `resolveFreshRouter` for `routes:list` / one-shot compile and as the hook `resolveRouter` (does **not** revert #45/#46 isolated bootstrap).
- Bumps `@ninots/framework` to `^0.12.1` (requires framework patch publish first).

## Root cause
In-process `resolveFreshRouter()` still reuses Bun-cached `routes/*.ts` from the long-lived serve process, so auto-hook rewrote a stale registry. A cold subprocess compile does not.

## Test plan
- [x] `bun test tests/Feature/ResolveFreshRouter.test.ts` + `TypedRoutes.test.ts`
- [x] `bun run type-check`
- [x] Focused verify: subprocess `routes:compile` includes a temporary `qa.smoke` name
- [ ] **Merge after** `@ninots/framework@0.12.1` is published
- [ ] Ivy SC#1 re-smoke after merge (named route appears in d.ts under `bun run dev`)

Fixes #47

## Out of scope
- Consilium S13
- Reopening #38 / #45