### PR TITLE
feat(serve): Bun fullstack HMR demo at /hmr-demo (Sprint 13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ bun run verify:route-types    # fail-fixture checks
 
 Named routes use `.name("recurso.ação")`; typed URLs via `route(name, params?)`.
 
+### Three “hot” mechanisms (do not confuse them)
+
+| Mechanism | What it updates | How you get it |
+| --- | --- | --- |
+| `bun --hot` (server) | Soft-reloads the **server** process / handlers | `bun run dev` → `bun --hot ./nino serve` |
+| Bun fullstack HMR (client) | Updates **browser** modules without a full page reload (`import.meta.hot`) | `Bun.serve({ development: true, routes: { … HTML imports } })` — try [`/hmr-demo`](http://localhost:3000/hmr-demo) |
+| Routes auto-hook | Rebuilds **`types/routes.d.ts`** (typed `route()`) | Watch → debounce → cold `nino routes:compile` (`compileArtifact`; see ninots#47) |
+
+Editing `resources/hmr-demo/hmr-demo.client.ts` exercises client HMR. Editing `routes/web.ts` exercises the auto-hook — not the browser HMR path. HTML demo routes are additive; the typed Router stays the source of truth for named routes.
+
 ## Docker (compose)
 
 Default stack: **app + SQLite volume** (no extra DB container).
@@ -117,6 +127,7 @@ bootstrap/        # app.ts, cli.ts, providers
 config/           # runtime configuration
 routes/           # web, api, console
 resources/views/  # TSX views (@ninots/view)
+resources/hmr-demo/ # Bun HTML-import client HMR demo (`/hmr-demo`)
 database/         # migrations, seeders
 types/            # routes.d.ts (compile artifact)
 nino              # CLI wrapper → bootstrap/cli.ts

--- a/bootstrap/app.ts
+++ b/bootstrap/app.ts
@@ -1,6 +1,7 @@
 import { Application, Container, createServeOptions, wireCoreServices } from "@ninots/framework";
 import type { Serve } from "bun";
 import appConfig from "@/config/app";
+import hmrDemoPage from "@/resources/hmr-demo/hmr-demo.html";
 import { getDatabaseManager } from "./database";
 import { registerProviders } from "./providers";
 
@@ -35,14 +36,30 @@ export async function bootstrap(): Promise<Application> {
 /**
  * Create Bun.serve options from a booted application.
  *
+ * Enables Bun fullstack `development` HMR and a dedicated HTML-import demo at
+ * `/hmr-demo`. The typed Router remains the source of truth for named routes;
+ * HTML routes are additive and do not regenerate `RouteRegistry`.
+ *
+ * After `@ninots/framework@0.13.0` is published, prefer passing `development`
+ * and `routes` through {@link createServeOptions} overrides (same fields).
+ * Setting them on the returned options keeps the demo working on 0.12.x runtimes
+ * whose helper ignored unknown keys.
+ *
  * @param app - Booted application instance
  * @returns Bun.serve configuration
  */
 export function createAppServeOptions(app: Application): AppServeOptions {
-    return createServeOptions(app, {
+    const options = createServeOptions(app, {
         error(_error: Error): Response {
             return new Response("Internal Server Error", { status: 500 });
         },
         idleTimeout: 30,
     }) as AppServeOptions;
+
+    options.development = app.getConfig().development;
+    options.routes = {
+        "/hmr-demo": hmrDemoPage,
+    };
+
+    return options;
 }

--- a/bootstrap/cli.ts
+++ b/bootstrap/cli.ts
@@ -91,6 +91,8 @@ class ServeCommand extends Command {
         this.info("Press Ctrl+C to stop");
 
         if (app.getConfig().development) {
+            this.info(`Client HMR demo: ${new URL("/hmr-demo", server.url).href}`);
+
             const routesArtifactRel = "types/routes.d.ts";
             const routesArtifactPath = path.join(process.cwd(), routesArtifactRel);
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "ninots-app",
       "dependencies": {
-        "@ninots/framework": "^0.12.1",
+        "@ninots/framework": "^0.13.0",
         "@ninots/view": "file:.deps/ninots-framework/packages/view",
       },
       "devDependencies": {
@@ -34,7 +34,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
-    "@ninots/framework": ["@ninots/framework@0.12.1", "", { "peerDependencies": { "typescript": "catalog:" }, "bin": { "nino": "nino" } }, "sha512-b6E7adKjajfCZKFgyt/jfoPrgFJR29GWNHs8arMmj5RR/nRNbDHiqCCyb8UxaliB7OeVCsAVeJMLgcSGp3Ubzg=="],
+    "@ninots/framework": ["@ninots/framework@0.13.0", "", { "peerDependencies": { "typescript": "catalog:" }, "bin": { "nino": "nino" } }, "sha512-GhzBtjT1LKM/2dqGKWUWsSzwdPlcD1OsmhuzI/ctIgp4GaV/i9r/9lHvithpqZO1ZZd4N/bT8p5W8QJ/jeakgg=="],
 
     "@ninots/view": ["@ninots/view@file:.deps/ninots-framework/packages/view", { "devDependencies": { "@types/bun": "latest" }, "peerDependencies": { "typescript": "^6.0.0" } }],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "test": "bun test"
     },
     "dependencies": {
-        "@ninots/framework": "^0.12.1",
+        "@ninots/framework": "^0.13.0",
         "@ninots/view": "file:.deps/ninots-framework/packages/view"
     },
     "devDependencies": {

--- a/resources/hmr-demo/hmr-demo.client.ts
+++ b/resources/hmr-demo/hmr-demo.client.ts
@@ -1,0 +1,22 @@
+/**
+ * Client entry for the Bun fullstack HMR demo (`/hmr-demo`).
+ *
+ * Prove client HMR with `import.meta.hot` — distinct from `bun --hot` (server)
+ * and from `startRoutesAutoHook` (typed `routes.d.ts` rebuild).
+ */
+
+const LABEL = "hmr-ready";
+
+function paintLabel(): void {
+    const el = document.getElementById("hmr-label");
+    if (el === null) {
+        return;
+    }
+    el.textContent = LABEL;
+}
+
+paintLabel();
+
+if (import.meta.hot) {
+    import.meta.hot.accept();
+}

--- a/resources/hmr-demo/hmr-demo.css
+++ b/resources/hmr-demo/hmr-demo.css
@@ -1,0 +1,106 @@
+:root {
+    --hmr-bg-top: #1a2332;
+    --hmr-bg-bottom: #0e141c;
+    --hmr-ink: #e8eef6;
+    --hmr-muted: #9aabbf;
+    --hmr-accent: #3d9cfd;
+    --hmr-label: #7dffc0;
+    --hmr-font-display: "Segoe UI", "Helvetica Neue", sans-serif;
+    --hmr-font-mono: ui-monospace, "Cascadia Code", "Consolas", monospace;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .hmr-demo__label {
+        animation: hmr-label-in 420ms ease-out both;
+    }
+
+    .hmr-demo__brand {
+        animation: hmr-brand-in 560ms ease-out both;
+    }
+}
+
+@keyframes hmr-label-in {
+    from {
+        opacity: 0;
+        transform: translateY(0.35rem);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes hmr-brand-in {
+    from {
+        letter-spacing: 0.35em;
+        opacity: 0;
+    }
+    to {
+        letter-spacing: 0.18em;
+        opacity: 1;
+    }
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    min-height: 100%;
+}
+
+body {
+    color: var(--hmr-ink);
+    font-family: var(--hmr-font-display);
+    background:
+        radial-gradient(120% 80% at 10% -10%, rgb(61 156 253 / 0.22), transparent 55%),
+        linear-gradient(165deg, var(--hmr-bg-top), var(--hmr-bg-bottom));
+}
+
+.hmr-demo {
+    margin: 0 auto;
+    max-width: 36rem;
+    padding: 18vh 1.5rem 4rem;
+}
+
+.hmr-demo__brand {
+    margin: 0 0 1.25rem;
+    color: var(--hmr-accent);
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+}
+
+.hmr-demo__title {
+    margin: 0 0 0.75rem;
+    font-size: clamp(1.75rem, 4vw, 2.35rem);
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+}
+
+.hmr-demo__lead {
+    margin: 0 0 2rem;
+    color: var(--hmr-muted);
+    font-size: 1rem;
+    line-height: 1.55;
+}
+
+.hmr-demo__lead code {
+    color: var(--hmr-ink);
+    font-family: var(--hmr-font-mono);
+    font-size: 0.88em;
+}
+
+.hmr-demo__label {
+    margin: 0;
+    color: var(--hmr-label);
+    font-family: var(--hmr-font-mono);
+    font-size: 1.35rem;
+    font-weight: 600;
+}

--- a/resources/hmr-demo/hmr-demo.html
+++ b/resources/hmr-demo/hmr-demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ninots · HMR demo</title>
+  <link rel="stylesheet" href="./hmr-demo.css" />
+</head>
+<body>
+  <main class="hmr-demo">
+    <p class="hmr-demo__brand">Ninots</p>
+    <h1 class="hmr-demo__title">Client HMR</h1>
+    <p class="hmr-demo__lead">
+      Edit <code>resources/hmr-demo/hmr-demo.client.ts</code> — the label below
+      updates without a full page reload when <code>development</code> HMR is on.
+    </p>
+    <p id="hmr-label" class="hmr-demo__label" data-hmr-label>boot</p>
+  </main>
+  <script type="module" src="./hmr-demo.client.ts"></script>
+</body>
+</html>

--- a/tests/Feature/HmrDemo.test.ts
+++ b/tests/Feature/HmrDemo.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { bootstrap, createAppServeOptions } from "@/bootstrap/app";
+
+const starterRoot = join(import.meta.dir, "../..");
+
+describe("Bun fullstack HMR demo (/hmr-demo)", () => {
+    test("createAppServeOptions enables development + dedicated HTML route", async () => {
+        const app = await bootstrap();
+        const options = createAppServeOptions(app);
+
+        expect(options.development).toBe(app.getConfig().development);
+        expect(options.routes).toBeDefined();
+        expect(options.routes?.["/hmr-demo"]).toBeDefined();
+    });
+
+    test("HTML demo coexists with typed Router fetch", async () => {
+        const app = await bootstrap();
+        const options = createAppServeOptions(app);
+        options.port = 0;
+        options.hostname = "127.0.0.1";
+
+        const server = Bun.serve(options);
+        try {
+            const home = await fetch(`http://127.0.0.1:${server.port}/`);
+            expect(home.status).toBe(200);
+
+            const demo = await fetch(`http://127.0.0.1:${server.port}/hmr-demo`);
+            expect(demo.status).toBe(200);
+            const body = await demo.text();
+            expect(body).toContain("hmr-label");
+            expect(body).toContain("Ninots");
+            expect(body.toLowerCase()).toContain("<!doctype html>");
+        } finally {
+            server.stop(true);
+        }
+    });
+
+    test("ServeCommand still wires compileArtifact spawn (no #47 regression)", async () => {
+        const cli = await readFile(join(starterRoot, "bootstrap/cli.ts"), "utf8");
+        const callStart = cli.indexOf("startRoutesAutoHook({");
+        expect(callStart).toBeGreaterThan(-1);
+
+        const hookBlock = cli.slice(callStart, cli.indexOf("}).catch", callStart));
+
+        expect(hookBlock).toContain("compileArtifact:");
+        expect(hookBlock).toContain('Bun.spawn(["bun", "./nino", "routes:compile"]');
+        expect(hookBlock).toContain("resolveRouter: resolveFreshRouter");
+    });
+});


### PR DESCRIPTION
## Summary
- Minimal HTML-import demo at `/hmr-demo` (`resources/hmr-demo/`) with client `import.meta.hot`
- `createAppServeOptions` sets Bun `development` + dedicated `routes` alongside typed Router `fetch`
- README documents three hot mechanisms (`bun --hot` vs client HMR vs routes auto-hook)
- **Preserves** `startRoutesAutoHook` + `compileArtifact` spawn (ninots#47 / SC#1)

Fixes #49

Depends on framework Sprint 13 surface ([nino-ts/framework#78](https://github.com/nino-ts/framework/issues/78)) — prefer merge/publish `@ninots/framework@0.13.0` then bump starter `^0.13.0` + `bun.lock`. Demo already works by setting fields on `Serve.Options` (compatible with 0.12.1 runtime).

## Test plan
- [x] `bun test tests/Feature/HmrDemo.test.ts`
- [x] `bun test` (38 pass) + `tsc --noEmit`
- [ ] Ivy: SC HMR — edit `hmr-demo.client.ts` → browser label updates without full reload
- [ ] Ivy: SC#1 regression — named route edit → `types/routes.d.ts` via auto-hook
- [ ] After framework 0.13.0: bump dep + lockfile (Dash/Remy)