### PR TITLE
[Sprint 16] TypedRoutes CRLF-stable Windows smoke

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 # Keep executable entrypoints LF so Linux containers can exec shebangs
 nino text eol=lf
 *.sh text eol=lf
+
+# Typed route registry must stay LF — Windows autocrlf must not rewrite compile artifact
+types/routes.d.ts text eol=lf

--- a/tests/Feature/TypedRoutes.test.ts
+++ b/tests/Feature/TypedRoutes.test.ts
@@ -15,7 +15,7 @@ describe("typed route registry", () => {
         expect(route("contact.create")).toBe("/contact");
     });
 
-    test("routes:compile is idempotent", () => {
+    test("routes:compile is idempotent", async () => {
         const first = spawnSync("bun", ["./nino", "routes:compile"], {
             cwd: starterRoot,
             encoding: "utf8",
@@ -28,11 +28,16 @@ describe("typed route registry", () => {
         expect(first.status).toBe(0);
         expect(second.status).toBe(0);
 
-        const diff = spawnSync("git", ["diff", "--exit-code", "types/routes.d.ts"], {
+        // Compare semantic content (normalize CRLF) instead of fragile `git diff`
+        // which fails on Windows when core.autocrlf rewrote the committed artifact.
+        const before = (await readFile(join(starterRoot, "types/routes.d.ts"), "utf8")).replace(/\r\n/g, "\n");
+        const third = spawnSync("bun", ["./nino", "routes:compile"], {
             cwd: starterRoot,
             encoding: "utf8",
         });
-        expect(diff.status).toBe(0);
+        expect(third.status).toBe(0);
+        const after = (await readFile(join(starterRoot, "types/routes.d.ts"), "utf8")).replace(/\r\n/g, "\n");
+        expect(after).toBe(before);
     });
 
     test("committed types/routes.d.ts matches registry shape", async () => {


### PR DESCRIPTION
## Summary
- Idempotent TypedRoutes assert without fragile `git diff`
- `.gitattributes`: `types/routes.d.ts text eol=lf`

## Test plan
- [ ] `bun test tests/Feature/TypedRoutes.test.ts` (Windows)
- [ ] Pair with `@ninots/routing@0.1.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route compilation reliability by ensuring generated route declarations remain unchanged when the command is run repeatedly.
  * Added consistent handling of line endings to prevent unnecessary changes to generated route files.

* **Tests**
  * Expanded coverage for route compilation idempotency and route listing output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->