### PR TITLE
feat: session↔auth adapter + bump ^0.2.0 (Fixes #56)

### DIFF
--- a/app/Providers/AppServiceProvider.ts
+++ b/app/Providers/AppServiceProvider.ts
@@ -7,11 +7,7 @@ import { createWideEvent, runWithContext } from "@ninots/logger";
 import { verifyCsrf, wideEventMiddleware, type MiddlewareStack } from "@ninots/middleware";
 import { mkdirSync } from "node:fs";
 import { UsersController } from "@/app/Http/Controllers/UsersController";
-import {
-    AUTH_MANAGER_KEY,
-    createSessionManager,
-    SESSION_MANAGER_KEY,
-} from "@/app/Session/createSessionServices";
+import { AUTH_MANAGER_KEY, createSessionManager, SESSION_MANAGER_KEY } from "@/app/Session/createSessionServices";
 import { UserService } from "@/app/Services/UserService";
 import authConfig from "@/config/auth";
 import csrfConfig from "@/config/csrf";
@@ -36,10 +32,7 @@ export class AppServiceProvider extends ServiceProvider {
         }
 
         this.app.singleton(SESSION_MANAGER_KEY, () => createSessionManager());
-        this.app.singleton(
-            AUTH_MANAGER_KEY,
-            () => new AuthManager({ default: authConfig.defaults.guard }),
-        );
+        this.app.singleton(AUTH_MANAGER_KEY, () => new AuthManager({ default: authConfig.defaults.guard }));
     }
 
     public override boot(): void {

--- a/app/Providers/AppServiceProvider.ts
+++ b/app/Providers/AppServiceProvider.ts
@@ -1,12 +1,21 @@
+import { AuthManager } from "@ninots/auth";
 import type { Application } from "@ninots/foundation";
 import { EVENT_DISPATCHER_KEY, MIDDLEWARE_STACK_KEY } from "@ninots/foundation";
 import { ServiceProvider } from "@ninots/container";
 import type { EventDispatcher } from "@ninots/events";
 import { createWideEvent, runWithContext } from "@ninots/logger";
 import { verifyCsrf, wideEventMiddleware, type MiddlewareStack } from "@ninots/middleware";
+import { mkdirSync } from "node:fs";
 import { UsersController } from "@/app/Http/Controllers/UsersController";
+import {
+    AUTH_MANAGER_KEY,
+    createSessionManager,
+    SESSION_MANAGER_KEY,
+} from "@/app/Session/createSessionServices";
 import { UserService } from "@/app/Services/UserService";
+import authConfig from "@/config/auth";
 import csrfConfig from "@/config/csrf";
+import sessionConfig from "@/config/session";
 
 /**
  * Application service provider.
@@ -21,6 +30,16 @@ export class AppServiceProvider extends ServiceProvider {
 
         this.app.singleton(UserService.name, () => new UserService(events));
         this.app.singleton(UsersController.name, () => new UsersController(this.app.make(UserService.name)));
+
+        if (sessionConfig.driver === "file") {
+            mkdirSync(sessionConfig.files, { recursive: true });
+        }
+
+        this.app.singleton(SESSION_MANAGER_KEY, () => createSessionManager());
+        this.app.singleton(
+            AUTH_MANAGER_KEY,
+            () => new AuthManager({ default: authConfig.defaults.guard }),
+        );
     }
 
     public override boot(): void {

--- a/app/Session/SessionAuthStoreAdapter.ts
+++ b/app/Session/SessionAuthStoreAdapter.ts
@@ -1,0 +1,44 @@
+import type { AuthSessionStore } from "@ninots/auth";
+import type { Session } from "@ninots/session";
+
+/**
+ * Adapts `@ninots/session` {@link Session} to auth's local {@link AuthSessionStore}.
+ *
+ * Lives in the app so `@ninots/auth` never imports `@ninots/session` (zero cross-deps).
+ */
+export class SessionAuthStoreAdapter implements AuthSessionStore {
+    constructor(private readonly session: Session) {}
+
+    public get<T = unknown>(key: string, defaultValue?: T): T {
+        return this.session.get(key, defaultValue);
+    }
+
+    public put(key: string, value: unknown): void {
+        this.session.set(key, value);
+    }
+
+    public forget(key: string): void {
+        this.session.forget(key);
+    }
+
+    public flush(): void {
+        for (const key of Object.keys(this.session.all())) {
+            this.session.forget(key);
+        }
+    }
+
+    public async regenerate(destroy?: boolean): Promise<boolean> {
+        if (destroy === true) {
+            this.flush();
+        }
+        await this.session.regenerate();
+        return true;
+    }
+
+    /**
+     * Underlying `@ninots/session` instance (persist via `save()`).
+     */
+    public unwrap(): Session {
+        return this.session;
+    }
+}

--- a/app/Session/createSessionServices.ts
+++ b/app/Session/createSessionServices.ts
@@ -1,0 +1,72 @@
+import type { SessionConfig, SessionDriver } from "@ninots/session";
+import { CookieDriver, FileDriver, SessionManager } from "@ninots/session";
+import sessionConfig from "@/config/session";
+import { SessionAuthStoreAdapter } from "./SessionAuthStoreAdapter";
+
+/**
+ * Build a {@link SessionConfig} from app config (fills required cookie fields).
+ */
+export function buildSessionConfig(): SessionConfig {
+    return {
+        cookie: sessionConfig.cookie,
+        driver: sessionConfig.driver,
+        files: sessionConfig.files,
+        httpOnly: sessionConfig.httpOnly,
+        lifetime: sessionConfig.lifetime,
+        path: sessionConfig.path,
+        sameSite: sessionConfig.sameSite,
+        secure: sessionConfig.secure,
+        table: sessionConfig.table,
+        ...(sessionConfig.domain !== undefined ? { domain: sessionConfig.domain } : {}),
+    };
+}
+
+/**
+ * Resolve the concrete session driver for the configured `driver` name.
+ *
+ * Database requires an app-injected {@link import("@ninots/session").DatabaseDriver}
+ * — register it in the container instead of using this helper.
+ */
+export function resolveSessionDriver(config: SessionConfig = buildSessionConfig()): SessionDriver {
+    switch (config.driver) {
+        case "cookie":
+            return new CookieDriver();
+        case "file":
+            return new FileDriver(config.files);
+        case "database":
+            throw new Error(
+                "Session driver \"database\" requires injecting DatabaseDriver (SessionConnectionInterface). " +
+                    "Override the SessionManager binding in a service provider.",
+            );
+        default: {
+            const _exhaustive: never = config.driver;
+            throw new Error(`Unknown session driver: ${String(_exhaustive)}`);
+        }
+    }
+}
+
+/**
+ * Create the canonical {@link SessionManager} for this app.
+ */
+export function createSessionManager(driver?: SessionDriver): SessionManager {
+    const config = buildSessionConfig();
+    return new SessionManager(driver ?? resolveSessionDriver(config), config);
+}
+
+/**
+ * Load (or create) a session and wrap it as auth's AuthSessionStore.
+ */
+export async function createAuthSessionStore(
+    manager: SessionManager,
+    sessionId?: string,
+): Promise<SessionAuthStoreAdapter> {
+    const session =
+        sessionId !== undefined ? await manager.getOrCreate(sessionId) : await manager.create();
+    return new SessionAuthStoreAdapter(session);
+}
+
+/** Container key for {@link SessionManager}. */
+export const SESSION_MANAGER_KEY = "SessionManager";
+
+/** Container key for {@link import("@ninots/auth").AuthManager}. */
+export const AUTH_MANAGER_KEY = "AuthManager";

--- a/app/Session/createSessionServices.ts
+++ b/app/Session/createSessionServices.ts
@@ -35,7 +35,7 @@ export function resolveSessionDriver(config: SessionConfig = buildSessionConfig(
             return new FileDriver(config.files);
         case "database":
             throw new Error(
-                "Session driver \"database\" requires injecting DatabaseDriver (SessionConnectionInterface). " +
+                'Session driver "database" requires injecting DatabaseDriver (SessionConnectionInterface). ' +
                     "Override the SessionManager binding in a service provider.",
             );
         default: {
@@ -60,8 +60,7 @@ export async function createAuthSessionStore(
     manager: SessionManager,
     sessionId?: string,
 ): Promise<SessionAuthStoreAdapter> {
-    const session =
-        sessionId !== undefined ? await manager.getOrCreate(sessionId) : await manager.create();
+    const session = sessionId !== undefined ? await manager.getOrCreate(sessionId) : await manager.create();
     return new SessionAuthStoreAdapter(session);
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "ninots-app",
       "dependencies": {
-        "@ninots/auth": "^0.1.0",
+        "@ninots/auth": "^0.2.0",
         "@ninots/cache": "^0.1.0",
         "@ninots/config": "^0.1.0",
         "@ninots/console": "^0.1.0",
@@ -18,7 +18,7 @@
         "@ninots/middleware": "^0.1.0",
         "@ninots/orm": "^0.1.0",
         "@ninots/routing": "^0.1.0",
-        "@ninots/session": "^0.1.0",
+        "@ninots/session": "^0.2.0",
         "@ninots/support": "^0.1.0",
         "@ninots/validation": "^0.1.0",
         "@ninots/view": "^0.1.0",
@@ -50,7 +50,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
-    "@ninots/auth": ["@ninots/auth@0.1.0", "", { "peerDependencies": { "bun": ">=1.0.0", "typescript": "^7.0.0" } }, "sha512-M79UeCNA89PLtlqpqTu95YYWxOajKTYv7qvhxWS/kAUEi//0xa7tGFJsOpt9njMysCUqlka7C5AOfv3riabqfw=="],
+    "@ninots/auth": ["@ninots/auth@0.2.0", "", { "peerDependencies": { "bun": ">=1.0.0", "typescript": "^7.0.0" } }, "sha512-tn4J7zWAU9rn3LoR5XmTTk8qNaNpygAh6xhv+3OfwZmFhLJ5yRLVCdOjbYiPgL5nTLKAIdWvLnFXTPb+iGaVPg=="],
 
     "@ninots/cache": ["@ninots/cache@0.1.0", "", { "peerDependencies": { "bun": ">=1.0.0", "typescript": "^7.0.0" } }, "sha512-2MMOgEC75N0SZ0Rd5787hKke3+zWdoMd4qvc9+Ok/1whz6UQMdlqTpYDKGs/4tePs+4fY7AgkLR7EslM4/hCNg=="],
 
@@ -76,7 +76,7 @@
 
     "@ninots/routing": ["@ninots/routing@0.1.1", "", { "peerDependencies": { "bun": ">=1.0.0", "typescript": "^7.0.0" } }, "sha512-/ExCi0n/ImDzZaROQkPob8FZcdE0C8lVJUgfreJ1iauA+Z25XNZLxuoNV4nnyBh+v8g5MV40UmG2o5+UaEWToA=="],
 
-    "@ninots/session": ["@ninots/session@0.1.0", "", { "peerDependencies": { "typescript": "^7.0.0" } }, "sha512-z0sOIJ7SOvrAEcgpBAYWoqYWaDr86JDimqiodpYSmE/MCzG6sAasMKU4a5uyJfdPjl+nIHnO8fmf7iICmH/qvg=="],
+    "@ninots/session": ["@ninots/session@0.2.0", "", { "peerDependencies": { "typescript": "^7.0.0" } }, "sha512-Ik/Ao+Xx3S/cHAZY70/KTpb8KSK4rQ9nSLJQThf8+K5OWwHmMvDixSlg7yxDYLlECwttEu6Bj3WXLyoGpu/0Jw=="],
 
     "@ninots/support": ["@ninots/support@0.1.0", "", { "peerDependencies": { "typescript": "^7.0.0" } }, "sha512-wHEvfqZkxwdhCNjl8UKcDFRDrMfbum2y4BXVhGRwDYVo5U+nGhLOAE/LZtN9UwRN507Bxg6HroWmxQEFVwyGsQ=="],
 

--- a/config/session.ts
+++ b/config/session.ts
@@ -1,0 +1,63 @@
+/**
+ * Session configuration (Laravel-like).
+ *
+ * Driver implementations live in `@ninots/session`. Auth consumes an
+ * `AuthSessionStore` adapter — see `SessionAuthStoreAdapter`.
+ */
+export default {
+    /**
+     * Session driver: cookie | file | database
+     *
+     * @default 'file'
+     */
+    driver: (Bun.env.SESSION_DRIVER ?? "file") as "cookie" | "file" | "database",
+
+    /**
+     * Lifetime in minutes.
+     *
+     * @default 120
+     */
+    lifetime: Number(Bun.env.SESSION_LIFETIME ?? 120),
+
+    /**
+     * Session cookie name.
+     *
+     * @default 'ninots_session'
+     */
+    cookie: Bun.env.SESSION_COOKIE ?? "ninots_session",
+
+    /**
+     * Cookie path.
+     */
+    path: "/",
+
+    /**
+     * Cookie domain (optional).
+     */
+    domain: Bun.env.SESSION_DOMAIN,
+
+    /**
+     * Secure cookies only.
+     */
+    secure: Bun.env.SESSION_SECURE === "true",
+
+    /**
+     * HTTP-only cookie flag.
+     */
+    httpOnly: true,
+
+    /**
+     * SameSite attribute.
+     */
+    sameSite: (Bun.env.SESSION_SAME_SITE ?? "lax") as "strict" | "lax" | "none",
+
+    /**
+     * File driver storage path.
+     */
+    files: Bun.env.SESSION_FILES ?? "storage/framework/sessions",
+
+    /**
+     * Database driver table name.
+     */
+    table: Bun.env.SESSION_TABLE ?? "sessions",
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "test": "bun test"
     },
     "dependencies": {
-        "@ninots/auth": "^0.1.0",
+        "@ninots/auth": "^0.2.0",
         "@ninots/cache": "^0.1.0",
         "@ninots/config": "^0.1.0",
         "@ninots/console": "^0.1.0",
@@ -38,7 +38,7 @@
         "@ninots/middleware": "^0.1.0",
         "@ninots/orm": "^0.1.0",
         "@ninots/routing": "^0.1.0",
-        "@ninots/session": "^0.1.0",
+        "@ninots/session": "^0.2.0",
         "@ninots/support": "^0.1.0",
         "@ninots/validation": "^0.1.0",
         "@ninots/view": "^0.1.0",

--- a/tests/Feature/SessionAuthAdapter.test.ts
+++ b/tests/Feature/SessionAuthAdapter.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import type { AuthManager } from "@ninots/auth";
+import type { Application } from "@ninots/foundation";
+import { FileDriver, SessionManager } from "@ninots/session";
+import {
+    AUTH_MANAGER_KEY,
+    createAuthSessionStore,
+    createSessionManager,
+    SESSION_MANAGER_KEY,
+} from "@/app/Session/createSessionServices";
+import { SessionAuthStoreAdapter } from "@/app/Session/SessionAuthStoreAdapter";
+import { bootstrap } from "@/bootstrap/app";
+
+describe("Session ↔ Auth adapter", () => {
+    const testDir = join(import.meta.dir, "..", "tmp-session-auth");
+    let app: Application;
+
+    beforeAll(async () => {
+        await mkdir(testDir, { recursive: true });
+        app = await bootstrap();
+    });
+
+    afterAll(async () => {
+        await rm(testDir, { force: true, recursive: true });
+    });
+
+    test("container resolves SessionManager and AuthManager", () => {
+        const manager = app.make<SessionManager>(SESSION_MANAGER_KEY);
+        const auth = app.make<AuthManager>(AUTH_MANAGER_KEY);
+        expect(manager).toBeInstanceOf(SessionManager);
+        expect(typeof auth.extend).toBe("function");
+    });
+
+    test("adapter maps session get/put/forget/flush to AuthSessionStore", async () => {
+        const driver = new FileDriver(testDir);
+        const manager = new SessionManager(driver, {
+            cookie: "ninots_session",
+            driver: "file",
+            files: testDir,
+            httpOnly: true,
+            lifetime: 120,
+            path: "/",
+            sameSite: "lax",
+            secure: false,
+        });
+
+        const store = await createAuthSessionStore(manager);
+        expect(store).toBeInstanceOf(SessionAuthStoreAdapter);
+
+        store.put("user_id", 42);
+        expect(store.get<number>("user_id")).toBe(42);
+
+        store.forget("user_id");
+        expect(store.get("user_id")).toBeUndefined();
+
+        store.put("a", 1);
+        store.put("b", 2);
+        store.flush();
+        expect(store.get("a")).toBeUndefined();
+        expect(store.get("b")).toBeUndefined();
+
+        const ok = await store.regenerate();
+        expect(ok).toBe(true);
+        await store.unwrap().save();
+    });
+
+    test("createSessionManager uses file driver by default", () => {
+        const manager = createSessionManager();
+        expect(manager).toBeInstanceOf(SessionManager);
+    });
+});


### PR DESCRIPTION
## Summary
- Adapter SessionAuthStoreAdapter: @ninots/session → AuthSessionStore
- Wire SessionManager + AuthManager in AppServiceProvider
- config/session.ts; bump session/auth to ^0.2.0 + bun.lock
- Feature tests for adapter seam

## Test plan
- [x] bun test (41 pass)
- [x] lock resolves session@0.2.0 auth@0.2.0

Closes #56

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable session management with cookie, file, and database storage options.
  * Added authentication integration with session-backed login state.
  * Added support for session regeneration, clearing, and persistence.
  * Added environment-based configuration for session lifetime, cookies, storage paths, and database tables.
* **Bug Fixes**
  * Ensured file-based session storage directories are created automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->