### PR TITLE
feat(sprint-18): wire social-auth + auth@0.3.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,5 +35,10 @@ SESSION_LIFETIME=120
 # CSRF (set a strong secret in production)
 CSRF_SECRET=change-me-in-production
 
+# Optional GitHub OAuth (@ninots/social-auth) — leave unset to skip wiring
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# GITHUB_REDIRECT_URI=http://localhost:3000/auth/github/callback
+
 # Queue (sync only — async drivers in a future sprint)
 QUEUE_CONNECTION=sync

--- a/app/Auth/createOAuthServices.ts
+++ b/app/Auth/createOAuthServices.ts
@@ -1,0 +1,30 @@
+import type { ProviderConfig } from "@ninots/social-auth";
+import { OAuthManager } from "@ninots/social-auth";
+
+/**
+ * Optional OAuth / social-auth wiring for the starter.
+ * Compose in the app only — `@ninots/auth` does not import `@ninots/social-auth`.
+ *
+ * Env keys (see `.env.example`): GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_REDIRECT_URI.
+ */
+export const OAUTH_MANAGER_KEY = "ninots.oauth";
+
+export function createOAuthManager(): OAuthManager | null {
+    const clientId = process.env.GITHUB_CLIENT_ID;
+    const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+    const redirectUri = process.env.GITHUB_REDIRECT_URI;
+
+    if (!clientId || !clientSecret || !redirectUri) {
+        return null;
+    }
+
+    const github: ProviderConfig = {
+        clientId,
+        clientSecret,
+        redirectUri,
+        scopes: ["read:user", "user:email"],
+        usePkce: true,
+    };
+
+    return new OAuthManager({ github });
+}

--- a/app/Providers/AppServiceProvider.ts
+++ b/app/Providers/AppServiceProvider.ts
@@ -6,6 +6,7 @@ import type { EventDispatcher } from "@ninots/events";
 import { createWideEvent, runWithContext } from "@ninots/logger";
 import { verifyCsrf, wideEventMiddleware, type MiddlewareStack } from "@ninots/middleware";
 import { mkdirSync } from "node:fs";
+import { createOAuthManager, OAUTH_MANAGER_KEY } from "@/app/Auth/createOAuthServices";
 import { UsersController } from "@/app/Http/Controllers/UsersController";
 import { AUTH_MANAGER_KEY, createSessionManager, SESSION_MANAGER_KEY } from "@/app/Session/createSessionServices";
 import { UserService } from "@/app/Services/UserService";
@@ -33,6 +34,11 @@ export class AppServiceProvider extends ServiceProvider {
 
         this.app.singleton(SESSION_MANAGER_KEY, () => createSessionManager());
         this.app.singleton(AUTH_MANAGER_KEY, () => new AuthManager({ default: authConfig.defaults.guard }));
+
+        const oauth = createOAuthManager();
+        if (oauth) {
+            this.app.singleton(OAUTH_MANAGER_KEY, () => oauth);
+        }
     }
 
     public override boot(): void {

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "ninots-app",
       "dependencies": {
-        "@ninots/auth": "^0.2.0",
+        "@ninots/auth": "^0.3.0",
         "@ninots/cache": "^0.1.0",
         "@ninots/config": "^0.1.0",
         "@ninots/console": "^0.1.0",
@@ -19,6 +19,7 @@
         "@ninots/orm": "^0.1.0",
         "@ninots/routing": "^0.1.0",
         "@ninots/session": "^0.2.0",
+        "@ninots/social-auth": "^0.1.0",
         "@ninots/support": "^0.1.0",
         "@ninots/validation": "^0.1.0",
         "@ninots/view": "^0.1.0",
@@ -50,7 +51,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
-    "@ninots/auth": ["@ninots/auth@0.2.0", "", { "peerDependencies": { "bun": ">=1.0.0", "typescript": "^7.0.0" } }, "sha512-tn4J7zWAU9rn3LoR5XmTTk8qNaNpygAh6xhv+3OfwZmFhLJ5yRLVCdOjbYiPgL5nTLKAIdWvLnFXTPb+iGaVPg=="],
+    "@ninots/auth": ["@ninots/auth@0.3.0", "", { "peerDependencies": { "bun": ">=1.0.0", "typescript": "^7.0.0" } }, "sha512-rQTf360auGUeJIY9dIXPA5it947polGyT6pBMDDFvheiOLtuZa81dd+xky3gj9mTYyv2+Fe4SCMyz90aJh2l6w=="],
 
     "@ninots/cache": ["@ninots/cache@0.1.0", "", { "peerDependencies": { "bun": ">=1.0.0", "typescript": "^7.0.0" } }, "sha512-2MMOgEC75N0SZ0Rd5787hKke3+zWdoMd4qvc9+Ok/1whz6UQMdlqTpYDKGs/4tePs+4fY7AgkLR7EslM4/hCNg=="],
 
@@ -77,6 +78,8 @@
     "@ninots/routing": ["@ninots/routing@0.1.1", "", { "peerDependencies": { "bun": ">=1.0.0", "typescript": "^7.0.0" } }, "sha512-/ExCi0n/ImDzZaROQkPob8FZcdE0C8lVJUgfreJ1iauA+Z25XNZLxuoNV4nnyBh+v8g5MV40UmG2o5+UaEWToA=="],
 
     "@ninots/session": ["@ninots/session@0.2.0", "", { "peerDependencies": { "typescript": "^7.0.0" } }, "sha512-Ik/Ao+Xx3S/cHAZY70/KTpb8KSK4rQ9nSLJQThf8+K5OWwHmMvDixSlg7yxDYLlECwttEu6Bj3WXLyoGpu/0Jw=="],
+
+    "@ninots/social-auth": ["@ninots/social-auth@0.1.0", "", { "peerDependencies": { "bun": ">=1.0.0", "typescript": "^7.0.0" } }, "sha512-LtZENKp/tgWHVNsmpgOurncoXDAfeh+HIDUPkELj24pvJIQ/qT5z1d5FpuS46X3e+BMFPZvUpifeFmmLPmoviA=="],
 
     "@ninots/support": ["@ninots/support@0.1.0", "", { "peerDependencies": { "typescript": "^7.0.0" } }, "sha512-wHEvfqZkxwdhCNjl8UKcDFRDrMfbum2y4BXVhGRwDYVo5U+nGhLOAE/LZtN9UwRN507Bxg6HroWmxQEFVwyGsQ=="],
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "test": "bun test"
     },
     "dependencies": {
-        "@ninots/auth": "^0.2.0",
+        "@ninots/auth": "^0.3.0",
         "@ninots/cache": "^0.1.0",
         "@ninots/config": "^0.1.0",
         "@ninots/console": "^0.1.0",
@@ -39,6 +39,7 @@
         "@ninots/orm": "^0.1.0",
         "@ninots/routing": "^0.1.0",
         "@ninots/session": "^0.2.0",
+        "@ninots/social-auth": "^0.1.0",
         "@ninots/support": "^0.1.0",
         "@ninots/validation": "^0.1.0",
         "@ninots/view": "^0.1.0",


### PR DESCRIPTION
## Summary
- Add `@ninots/social-auth@^0.1.0` + bump `@ninots/auth` to `^0.3.0`
- Optional app wiring: `createOAuthServices` + register when `GITHUB_*` env present
- `.env.example` documents OAuth keys (names only)

## Blockers (do not merge until)
- [ ] npm+JSR `@ninots/social-auth@0.1.0` published (CEO Trusted Publisher)
- [ ] `@ninots/auth@0.3.0` published after auth PR #7 merge + release
- [ ] Follow-up: commit updated `bun.lock` for frozen-lockfile CI

## Test plan
- [x] Local smoke via `bun link`
- [ ] After publish: `bun install --frozen-lockfile` green

Fixes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional GitHub OAuth configuration.
  * GitHub sign-in services are enabled when valid OAuth settings are provided.
  * OAuth can be skipped by leaving the configuration unset.

* **Chores**
  * Updated authentication support and added social authentication capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->